### PR TITLE
Updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,9 @@ add_library(
   # IK Solver
   src/ik/moveit_ik_solver.cpp
   # Display
-  src/display/ros_display.cpp)
+  src/display/ros_display.cpp
+  # Target pose generator
+  src/target_pose_generator/transformed_point_cloud_target_pose_generator.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} reach::reach)
 
 # Plugin Library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,9 +35,9 @@ catkin_package(
 
 include_directories(${catkin_INCLUDE_DIRS} include)
 
-# Plugins
+# Plugin Implementations
 add_library(
-  ${PROJECT_NAME}_plugins
+  ${PROJECT_NAME}
   src/utils.cpp
   # Evaluator
   src/evaluation/manipulability_moveit.cpp
@@ -47,7 +47,11 @@ add_library(
   src/ik/moveit_ik_solver.cpp
   # Display
   src/display/ros_display.cpp)
-target_link_libraries(${PROJECT_NAME}_plugins ${catkin_LIBRARIES} reach::reach)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} reach::reach)
+
+# Plugin Library
+add_library(${PROJECT_NAME}_plugins SHARED src/plugins.cpp)
+target_link_libraries(${PROJECT_NAME}_plugins ${PROJECT_NAME})
 
 # Reach study node
 add_executable(${PROJECT_NAME}_node src/reach_study_node.cpp)
@@ -65,7 +69,7 @@ add_subdirectory(demo)
 # ######################################################################################################################
 
 install(
-  TARGETS ${PROJECT_NAME}_plugins ${PROJECT_NAME}_node
+  TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_plugins ${PROJECT_NAME}_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/README.md
+++ b/README.md
@@ -176,3 +176,18 @@ Parameters:
   - The length (in meters) of the arrow markers representing the target Cartesian points
 - **`use_full_color_range`** (optional, default: False)
   - Colorize the heat map using the full range of colors (such that the target with the lowest score is the deepest hue of blue, and the target with the highest score is the deepest hue of red)
+
+## Target Pose Generator Plugins
+
+### Transformed Point Cloud Target Pose Generator
+
+This plugin inherits `reach::PointCloudTargetPoseGenerator`, which creates target reach study waypoints from a point cloud file with normals, and transforms the point cloud points into a desired URDF frame (typically the kinematic base frame of the robot).
+
+Parameters:
+
+- **`pcd_file`**
+  - The path to the point cloud file (.pcd format), in the `package://` or `file://` URI
+- **`points_frame`**
+  - The frame of the URDF to which the point cloud points are relative (i.e. the origin frame of the point cloud)
+- **`target_frame`**
+  - The frame into which the point cloud points should be transformed for the reach study purposes. This should be the kinematic base frame of the robot

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -5,4 +5,4 @@
 - git:
    local-name: reach
    uri: https://github.com/ros-industrial/reach.git
-   version: 1.1.0
+   version: 1.2.0

--- a/include/reach_ros/target_pose_generator/transformed_point_cloud_target_pose_generator.h
+++ b/include/reach_ros/target_pose_generator/transformed_point_cloud_target_pose_generator.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Southwest Research Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef REACH_ROS_TARGET_POSE_GENERATOR_POINT_CLOUD_TARGET_POSE_GENERATOR_H
+#define REACH_ROS_TARGET_POSE_GENERATOR_POINT_CLOUD_TARGET_POSE_GENERATOR_H
+
+#include <reach/plugins/point_cloud_target_pose_generator.h>
+
+namespace reach_ros
+{
+class TransformedPointCloudTargetPoseGenerator : public reach::PointCloudTargetPoseGenerator
+{
+public:
+  TransformedPointCloudTargetPoseGenerator(std::string filename, std::string source_frame, std::string target_frame);
+
+  reach::VectorIsometry3d generate() const override;
+
+private:
+  std::string filename_;
+  std::string points_frame_;
+  std::string target_frame_;
+};
+
+struct TransformedPointCloudTargetPoseGeneratorFactory : public reach::PointCloudTargetPoseGeneratorFactory
+{
+  using PointCloudTargetPoseGeneratorFactory::PointCloudTargetPoseGeneratorFactory;
+  reach::TargetPoseGenerator::ConstPtr create(const YAML::Node& config) const override;
+};
+
+}  // namespace reach_ros
+
+#endif  // REACH_ROS_TARGET_POSE_GENERATOR_POINT_CLOUD_TARGET_POSE_GENERATOR_H

--- a/src/display/ros_display.cpp
+++ b/src/display/ros_display.cpp
@@ -156,5 +156,3 @@ reach::Display::ConstPtr ROSDisplayFactory::create(const YAML::Node& config) con
 
 }  // namespace display
 }  // namespace reach_ros
-
-EXPORT_DISPLAY_PLUGIN(reach_ros::display::ROSDisplayFactory, ROSDisplay)

--- a/src/display/ros_display.cpp
+++ b/src/display/ros_display.cpp
@@ -140,7 +140,7 @@ reach::Display::ConstPtr ROSDisplayFactory::create(const YAML::Node& config) con
 
   // Optionally add a collision mesh
   const std::string collision_mesh_filename_key = "collision_mesh_filename";
-  const std::string collision_mesh_frame_key = "collision_mesh_key";
+  const std::string collision_mesh_frame_key = "collision_mesh_frame";
   if (config[collision_mesh_filename_key])
   {
     auto collision_mesh_filename = reach::get<std::string>(config, collision_mesh_filename_key);

--- a/src/evaluation/distance_penalty_moveit.cpp
+++ b/src/evaluation/distance_penalty_moveit.cpp
@@ -81,5 +81,3 @@ reach::Evaluator::ConstPtr DistancePenaltyMoveItFactory::create(const YAML::Node
 
 }  // namespace evaluation
 }  // namespace reach_ros
-
-EXPORT_IK_SOLVER_PLUGIN(reach_ros::evaluation::DistancePenaltyMoveItFactory, DistancePenaltyMoveIt)

--- a/src/evaluation/joint_penalty_moveit.cpp
+++ b/src/evaluation/joint_penalty_moveit.cpp
@@ -80,5 +80,3 @@ reach::Evaluator::ConstPtr JointPenaltyMoveItFactory::create(const YAML::Node& c
 
 }  // namespace evaluation
 }  // namespace reach_ros
-
-EXPORT_EVALUATOR_PLUGIN(reach_ros::evaluation::JointPenaltyMoveItFactory, JointPenaltyMoveIt)

--- a/src/evaluation/manipulability_moveit.cpp
+++ b/src/evaluation/manipulability_moveit.cpp
@@ -256,7 +256,3 @@ double calculateCharacteristicLength(moveit::core::RobotModelConstPtr model, con
 
 }  // namespace evaluation
 }  // namespace reach_ros
-
-EXPORT_EVALUATOR_PLUGIN(reach_ros::evaluation::ManipulabilityMoveItFactory, ManipulabilityMoveIt)
-EXPORT_EVALUATOR_PLUGIN(reach_ros::evaluation::ManipulabilityScaledFactory, ManipulabilityScaledMoveIt)
-EXPORT_EVALUATOR_PLUGIN(reach_ros::evaluation::ManipulabilityRatioFactory, ManipulabilityRatioMoveIt)

--- a/src/ik/moveit_ik_solver.cpp
+++ b/src/ik/moveit_ik_solver.cpp
@@ -227,6 +227,3 @@ reach::IKSolver::ConstPtr DiscretizedMoveItIKSolverFactory::create(const YAML::N
 
 }  // namespace ik
 }  // namespace reach_ros
-
-EXPORT_IK_SOLVER_PLUGIN(reach_ros::ik::MoveItIKSolverFactory, MoveItIKSolver)
-EXPORT_IK_SOLVER_PLUGIN(reach_ros::ik::DiscretizedMoveItIKSolverFactory, DiscretizedMoveItIKSolverFactory)

--- a/src/ik/moveit_ik_solver.cpp
+++ b/src/ik/moveit_ik_solver.cpp
@@ -132,7 +132,7 @@ reach::IKSolver::ConstPtr MoveItIKSolverFactory::create(const YAML::Node& config
 
   // Optionally add a collision mesh
   const std::string collision_mesh_filename_key = "collision_mesh_filename";
-  const std::string collision_mesh_frame_key = "collision_mesh_key";
+  const std::string collision_mesh_frame_key = "collision_mesh_frame";
   if (config[collision_mesh_filename_key])
   {
     auto collision_mesh_filename = reach::get<std::string>(config, collision_mesh_filename_key);
@@ -204,7 +204,7 @@ reach::IKSolver::ConstPtr DiscretizedMoveItIKSolverFactory::create(const YAML::N
 
   // Optionally add a collision mesh
   const std::string collision_mesh_filename_key = "collision_mesh_filename";
-  const std::string collision_mesh_frame_key = "collision_mesh_key";
+  const std::string collision_mesh_frame_key = "collision_mesh_frame";
   if (config[collision_mesh_filename_key])
   {
     auto collision_mesh_filename = reach::get<std::string>(config, collision_mesh_filename_key);

--- a/src/plugins.cpp
+++ b/src/plugins.cpp
@@ -1,0 +1,18 @@
+#include <reach_ros/display/ros_display.h>
+#include <reach_ros/evaluation/distance_penalty_moveit.h>
+#include <reach_ros/evaluation/joint_penalty_moveit.h>
+#include <reach_ros/evaluation/manipulability_moveit.h>
+#include <reach_ros/ik/moveit_ik_solver.h>
+#include <reach_ros/target_pose_generator/transformed_point_cloud_target_pose_generator.h>
+
+#include <reach/plugin_utils.h>
+EXPORT_DISPLAY_PLUGIN(reach_ros::display::ROSDisplayFactory, ROSDisplay)
+EXPORT_IK_SOLVER_PLUGIN(reach_ros::evaluation::DistancePenaltyMoveItFactory, DistancePenaltyMoveIt)
+EXPORT_EVALUATOR_PLUGIN(reach_ros::evaluation::JointPenaltyMoveItFactory, JointPenaltyMoveIt)
+EXPORT_EVALUATOR_PLUGIN(reach_ros::evaluation::ManipulabilityMoveItFactory, ManipulabilityMoveIt)
+EXPORT_EVALUATOR_PLUGIN(reach_ros::evaluation::ManipulabilityScaledFactory, ManipulabilityScaledMoveIt)
+EXPORT_EVALUATOR_PLUGIN(reach_ros::evaluation::ManipulabilityRatioFactory, ManipulabilityRatioMoveIt)
+EXPORT_IK_SOLVER_PLUGIN(reach_ros::ik::MoveItIKSolverFactory, MoveItIKSolver)
+EXPORT_IK_SOLVER_PLUGIN(reach_ros::ik::DiscretizedMoveItIKSolverFactory, DiscretizedMoveItIKSolverFactory)
+EXPORT_TARGET_POSE_GENERATOR_PLUGIN(reach_ros::TransformedPointCloudTargetPoseGeneratorFactory,
+                                    TransformedPointCloudTargetPoseGenerator)

--- a/src/target_pose_generator/transformed_point_cloud_target_pose_generator.cpp
+++ b/src/target_pose_generator/transformed_point_cloud_target_pose_generator.cpp
@@ -1,0 +1,49 @@
+#include <reach_ros/target_pose_generator/transformed_point_cloud_target_pose_generator.h>
+#include <reach_ros/utils.h>
+
+#include <reach/plugin_utils.h>
+#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+#include <yaml-cpp/yaml.h>
+
+namespace reach_ros
+{
+TransformedPointCloudTargetPoseGenerator::TransformedPointCloudTargetPoseGenerator(std::string filename,
+                                                                                   std::string points_frame,
+                                                                                   std::string target_frame)
+  : reach::PointCloudTargetPoseGenerator(filename)
+  , points_frame_(std::move(points_frame))
+  , target_frame_(std::move(target_frame))
+{
+}
+
+reach::VectorIsometry3d TransformedPointCloudTargetPoseGenerator::generate() const
+{
+  reach::VectorIsometry3d target_poses = PointCloudTargetPoseGenerator::generate();
+
+  // Look up the transform between the source and target frame
+  tf2_ros::Buffer buffer;
+  tf2_ros::TransformListener listener(buffer);
+  Eigen::Isometry3d transform =
+      tf2::transformToEigen(buffer.lookupTransform(target_frame_, points_frame_, ros::Time(0), ros::Duration(3.0)));
+
+  // Apply the transform to the poses
+  for (Eigen::Isometry3d& pose : target_poses)
+  {
+    pose = transform * pose;
+  }
+
+  return target_poses;
+}
+
+reach::TargetPoseGenerator::ConstPtr
+TransformedPointCloudTargetPoseGeneratorFactory::create(const YAML::Node& config) const
+{
+  std::string filename = reach::get<std::string>(config, "pcd_file");
+  std::string source_frame = reach::get<std::string>(config, "points_frame");
+  std::string target_frame = reach::get<std::string>(config, "target_frame");
+  return std::make_shared<TransformedPointCloudTargetPoseGenerator>(filename, source_frame, target_frame);
+}
+
+}  // namespace reach_ros


### PR DESCRIPTION
This PR:
- Fixes the key for specifying the frame of the collision mesh
- Exposes interface implementations in a library for linking by downstream projects
- Adds a target pose generator that can transform point clouds from their origin frames into the robot kinematic base frame to resolve https://github.com/ros-industrial/reach/issues/42