### PR TITLE
Collision distance evaluator update

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Parameters:
 - **`touch_links`**
   - The names of the robot links with which the reach object mesh is allowed to collide
 - **`exponent`**
-  - score = (closest_distance_to_collision / distance_threshold)^exponent.
+  - score = min(abs(closest_distance_to_collision / distance_threshold), 1.0)^exponent.
 
 ### Joint Penalty
 

--- a/README.md
+++ b/README.md
@@ -106,16 +106,16 @@ Parameters:
   - The name of the planning group to be used to solve the robot's inverse kinematics
 - **`distance_threshold`**
   - The distance between 2 closest surfaces to collision under which an inverse kinematics solution will be considered invalid
-- **`collision_mesh_filename`**
+- **`collision_mesh_filename`** (optional)
   - The filename (in ROS package URI format) of the reach object mesh to be used to do collision checking
   - Example: `package://<your_package>/<folder>/<filename>.stl
-- **`collision_mesh_frame`**
+- **`collision_mesh_frame`** (optional)
   - The TF frame to which the collision mesh should be attached
   - If left unspecified, the collision mesh will be attached to the kinematic base frame associated with `planning_group`
 - **`touch_links`**
   - The names of the robot links with which the reach object mesh is allowed to collide
 - **`exponent`**
-  - score = (closest_distance_to_collision - distance_threshold)^exponent.
+  - score = (closest_distance_to_collision / distance_threshold)^exponent.
 
 ### Joint Penalty
 
@@ -140,9 +140,9 @@ Parameters:
 - **`distance_threshold`**
   - The distance from nearest collision at which to invalidate an IK solution. For example, if this parameter is
   set to 0.1m, then IK solutions whose distance to nearest collision is less than 0.1m will be invalidated
-- **`collision_mesh_filename`**
+- **`collision_mesh_filename`** (optional)
   - The file path to the collision mesh model of the workpiece, in the `package://` or 'file://' URI format
-- **`collision_mesh_frame`**
+- **`collision_mesh_frame`** (optional)
   - The TF frame to which the collision mesh should be attached
   - If left unspecified, the collision mesh will be attached to the kinematic base frame associated with `planning_group`
 - **`touch_links`**
@@ -162,9 +162,9 @@ Parameters:
 - **`distance_threshold`**
   - The distance from nearest collision at which to invalidate an IK solution. For example, if this parameter is
   set to 0.1m, then IK solutions whose distance to nearest collision is less than 0.1m will be invalidated
-- **`collision_mesh_filename`**
+- **`collision_mesh_filename`** (optional)
   - The file path to the collision mesh model of the workpiece, in the `package://` or 'file://' URI format
-- **`collision_mesh_frame`**
+- **`collision_mesh_frame`** (optional)
   - The TF frame to which the collision mesh should be attached
   - If left unspecified, the collision mesh will be attached to the kinematic base frame associated with `planning_group`
 - **`touch_links`**
@@ -196,9 +196,9 @@ Unreachable points are colorized black. There are two methods for computing the 
 
 Parameters:
 
-- **`collision_mesh_filename`**
+- **`collision_mesh_filename`** (optional)
   - The file path to the collision mesh model of the workpiece, in the `package://` or 'file://' URI format
-- **`collision_mesh_frame`**
+- **`collision_mesh_frame`** (optional)
   - The TF frame to which the collision mesh should be attached
   - If left unspecified, the collision mesh will be attached to `kinematic_base_frame`
 - **`kinematic_base_frame`**

--- a/demo/results/reach_study/reach.db.xml
+++ b/demo/results/reach_study/reach.db.xml
@@ -1779,34 +1779,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.04704982527519874e+00</second>
+						<second>-1.04579160161709428e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.90524129922294350e+00</second>
+						<second>1.89722750521740280e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.17713983439662750e+00</second>
+						<second>-1.17886147819714560e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.68396603444430437e-01</second>
+						<second>5.59657479163221616e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.81392602532812819e+00</second>
+						<second>-1.81322787575109778e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.49039613489604905e+00</second>
+						<second>-1.48828517959360185e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-5.08985272695114510e-01</second>
+						<second>-5.09092582163428564e-01</second>
 					</item>
 				</goal_state>
-				<score>1.58693416752215088e+00</score>
+				<score>1.08393256687600942e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -1869,34 +1869,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-8.93850295354228219e-01</second>
+						<second>1.62593800953196688e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>9.13643503819191904e-01</second>
+						<second>9.02511299745119899e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.58489453926075119e+00</second>
+						<second>-1.12692415059950712e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-5.70841942600749497e-01</second>
+						<second>2.58170489865553243e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.78446190093087842e+00</second>
+						<second>-2.36312000595665284e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.23927857945782338e+00</second>
+						<second>1.43386872415623290e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-7.88169803298386040e-01</second>
+						<second>7.88681240076082091e-01</second>
 					</item>
 				</goal_state>
-				<score>2.32288892988698636e+00</score>
+				<score>1.66111168419094152e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -1959,34 +1959,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70916885857598388e+00</second>
+						<second>-9.79475776664147757e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.80872433337070659e+00</second>
+						<second>-1.02086007416652169e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.38775863373580544e+00</second>
+						<second>1.27294632552552489e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.30205970064226544e-02</second>
+						<second>1.07212964117587606e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.50159876650583168e-01</second>
+						<second>1.36856752204513343e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.65171257776160441e+00</second>
+						<second>-2.06891475782858869e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.58698288929702569e-01</second>
+						<second>-8.58874499965357141e-01</second>
 					</item>
 				</goal_state>
-				<score>2.85399295583344736e+00</score>
+				<score>1.59264585426558136e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -2049,34 +2049,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.25625441991713438e+00</second>
+						<second>-1.16193322503912633e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.06463692436496760e+00</second>
+						<second>4.28428387076098927e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.52423258363754299e+00</second>
+						<second>1.91153215901836315e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.09211298682184932e+00</second>
+						<second>2.43911000297301017e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.22531969061136725e+00</second>
+						<second>1.09737228537628129e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.24837128750967075e-01</second>
+						<second>9.24536190634173360e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-6.00426143532976409e-01</second>
+						<second>6.00509513947570572e-01</second>
 					</item>
 				</goal_state>
-				<score>1.97715042274547481e+00</score>
+				<score>1.35664068928587705e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -2139,34 +2139,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.04431526914520534e+00</second>
+						<second>1.31732162509092365e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.20118503365351259e+00</second>
+						<second>2.57767229836935341e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.24338319376832440e+00</second>
+						<second>1.04601207948588826e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.58802670530156020e-01</second>
+						<second>1.45168673972490159e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.69236754112539955e+00</second>
+						<second>1.27155730950695323e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.83944729130832219e+00</second>
+						<second>-2.96982983215413254e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.42673902531544927e-01</second>
+						<second>9.42870176967499862e-01</second>
 					</item>
 				</goal_state>
-				<score>2.46331657180142960e+00</score>
+				<score>1.78383101102894875e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -2229,34 +2229,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85490735972754139e+00</second>
+						<second>-1.90824652356106284e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.85755453350982225e+00</second>
+						<second>-1.45356340015587637e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.66141532481036602e+00</second>
+						<second>1.57421548795214261e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50891182085985509e+00</second>
+						<second>4.43948224189707696e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.59843576502383611e+00</second>
+						<second>5.25389380485719815e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.14577890144303929e+00</second>
+						<second>9.02835849719668904e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.06251881508530110e+00</second>
+						<second>1.06235146506180711e+00</second>
 					</item>
 				</goal_state>
-				<score>2.97054593365499064e+00</score>
+				<score>2.04213491586836243e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -2319,34 +2319,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>8.42402665292957264e-01</second>
+						<second>-8.90416710067824524e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.03972892611279999e+00</second>
+						<second>1.51810557701132942e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.91738019749592126e+00</second>
+						<second>1.72138734188055365e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.05225107214299474e+00</second>
+						<second>-2.64845970576222589e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.36289837240485867e+00</second>
+						<second>1.41673499537251857e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.45703089861990032e+00</second>
+						<second>3.79727395381234956e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.02760215446629810e+00</second>
+						<second>1.02752084715468683e+00</second>
 					</item>
 				</goal_state>
-				<score>2.56560501766347526e+00</score>
+				<score>1.83859134844622990e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -2409,34 +2409,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75863181831619619e+00</second>
+						<second>1.86074417243399370e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>-2.95443849774183054e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.50842630936993460e+00</second>
+						<second>1.50914318318281682e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.09844116343838927e+00</second>
+						<second>2.46769284379589626e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.22880811047857064e+00</second>
+						<second>7.97024855384040332e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.32223972544061102e-01</second>
+						<second>-2.81871344513693378e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-6.88941068081233787e-01</second>
+						<second>6.88964561397583219e-01</second>
 					</item>
 				</goal_state>
-				<score>2.34185636336967962e+00</score>
+				<score>1.59360887768382975e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -2499,34 +2499,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>4.02815283377608413e-01</second>
+						<second>-4.31340906414773073e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.32196315313202661e+00</second>
+						<second>-1.69409606954169578e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.74531476894885840e+00</second>
+						<second>1.65086583346622140e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.06744628099968031e+00</second>
+						<second>4.29327427938796413e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.54681925022388733e+00</second>
+						<second>1.61263935376231826e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.32901543069267669e+00</second>
+						<second>-2.08220896820956769e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.46472559637339095e+00</second>
+						<second>-1.46455953686523443e+00</second>
 					</item>
 				</goal_state>
-				<score>2.71436649774492755e+00</score>
+				<score>1.63744540091715074e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -2589,34 +2589,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-6.57576144585789724e-01</second>
+						<second>-4.15836917517000415e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.38520769557189194e+00</second>
+						<second>1.30493142636248471e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.56836191426743587e+00</second>
+						<second>-1.91977859953784957e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.05820867373437810e+00</second>
+						<second>9.75956150664608196e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.57954272666457762e+00</second>
+						<second>-1.59377170436251414e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.14777559698149437e-02</second>
+						<second>6.24089256939497905e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.48867782086259748e+00</second>
+						<second>-1.48883406613657088e+00</second>
 					</item>
 				</goal_state>
-				<score>2.28036110839625605e+00</score>
+				<score>1.62973348867357759e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -2679,34 +2679,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-9.61769435153357999e-01</second>
+						<second>-1.89259334009316249e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.53527393126922029e+00</second>
+						<second>-1.57066593676098099e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91920074441020461e+00</second>
+						<second>-1.89942742225766770e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.78051982417526200e-01</second>
+						<second>-2.24615994098465110e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.78623868018483334e+00</second>
+						<second>-2.85468696301397662e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.54983483387536730e-01</second>
+						<second>9.35601269890887655e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.11734054201285948e+00</second>
+						<second>-1.11744174771433680e+00</second>
 					</item>
 				</goal_state>
-				<score>2.61844062927643639e+00</score>
+				<score>1.91361229655276716e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -2859,34 +2859,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.79938620655980785e+00</second>
+						<second>-1.72254820264191766e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.55471389223816203e+00</second>
+						<second>-1.45167728134555674e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.81086176083200789e+00</second>
+						<second>-1.91843687991093570e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.07574367107000857e-01</second>
+						<second>-2.43735168380967737e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.77510794894695262e-02</second>
+						<second>3.08142223945118454e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.42870290818992296e+00</second>
+						<second>-1.32708761733468350e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.83966934771623625e+00</second>
+						<second>-1.83963776601617179e+00</second>
 					</item>
 				</goal_state>
-				<score>1.79344021444480561e+00</score>
+				<score>1.50497137690942168e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -2949,37 +2949,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.82319241455661607e+00</second>
+						<second>-1.20534046218778235e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.76432290108184131e+00</second>
+						<second>2.27394499079882806e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.83059383206950188e+00</second>
+						<second>-1.41370347278535435e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.39322415904739660e+00</second>
+						<second>1.82292135262531407e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.30057357177609689e-02</second>
+						<second>-1.86045511504265981e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.91063108551034189e+00</second>
+						<second>-3.78340562446647710e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.64531392539713672e+00</second>
+						<second>-1.64526272011658925e+00</second>
 					</item>
 				</goal_state>
-				<score>2.29073110119196288e+00</score>
+				<score>1.67560140216059444e-01</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -3039,34 +3039,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.89224372143655883e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.92419348544080515e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.45379735976819657e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-9.12021362349807130e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>7.69580921312952748e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.09586556999951928e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.26211855936764339e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>2.08245715973736339e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -3129,34 +3129,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61574364709943974e+00</second>
+						<second>-1.90262964002403101e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.90554818157082639e+00</second>
+						<second>1.31408205260972122e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.92251346147564184e-01</second>
+						<second>-1.56286868090138475e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.36200116306952368e-01</second>
+						<second>3.97361798339151640e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.98438125951423938e-01</second>
+						<second>2.88253880184994316e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14150000000000018e+00</second>
+						<second>-1.73144058566033987e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.02188840136405146e+00</second>
+						<second>2.02193066345783512e+00</second>
 					</item>
 				</goal_state>
-				<score>2.10276731817181783e+00</score>
+				<score>1.32390018610693910e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -3219,34 +3219,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-6.14844153663396731e-01</second>
+						<second>1.77174127937248382e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.73192004988739034e+00</second>
+						<second>-1.83121074739372736e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91864127120909411e+00</second>
+						<second>-1.80399012636409606e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.80174455230055464e+00</second>
+						<second>7.36396329952856088e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.68907017700687856e+00</second>
+						<second>2.83965635325721255e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.77267913381770237e-01</second>
+						<second>-1.85027769032435829e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87535714819619037e+00</second>
+						<second>-1.87547634644211803e+00</second>
 					</item>
 				</goal_state>
-				<score>1.22198591871536810e+00</score>
+				<score>1.47121447864186627e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -3309,34 +3309,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91969890351458461e+00</second>
+						<second>-1.85742434894983610e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96320782660357018e+00</second>
+						<second>-2.03270315666874923e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37175494457080327e+00</second>
+						<second>1.82615153474688441e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.39425974887273663e+00</second>
+						<second>8.43665851789972221e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.50759068322008760e+00</second>
+						<second>-2.09876888246462667e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13136781864708441e-01</second>
+						<second>9.80175115967550359e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.55297671528658121e+00</second>
+						<second>1.55302625364747815e+00</second>
 					</item>
 				</goal_state>
-				<score>3.08622522320939607e+00</score>
+				<score>1.81627223600010601e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -3399,37 +3399,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-6.47944429134393096e-01</second>
+						<second>1.71360888104246234e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.60098987279618732e+00</second>
+						<second>-1.72525418219306625e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.91979993914931546e+00</second>
+						<second>1.74939377488426295e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.76405795999474257e-01</second>
+						<second>-2.56390212778576876e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.41681737236231409e+00</second>
+						<second>-4.97251793210201021e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.74845502027980615e+00</second>
+						<second>1.56895442567372334e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.13519190016531590e+00</second>
+						<second>2.13527868589845315e+00</second>
 					</item>
 				</goal_state>
-				<score>1.24091798083233673e+00</score>
+				<score>1.08220417275110906e-01</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -3489,37 +3489,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-8.10518512175034456e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.78711817181148769e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.06479846098511066e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.81385854035356253e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.06770335838206698e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.02099715803790358e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>8.51358097071691494e-02</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -3579,34 +3579,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.76193653783328918e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.03392381988344373e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.79752232548727697e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.24229450869103220e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.70310767624698656e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.14406327843928501e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.70658835756407079e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>1.66897292782709289e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -3669,34 +3669,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.57569257089391246e+00</second>
+						<second>-1.91764270618650112e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.14040635566775683e+00</second>
+						<second>-3.88802893217232215e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.68096307114115162e+00</second>
+						<second>1.12091431129206365e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.81583817027514560e-01</second>
+						<second>2.69251903066517251e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.37462622959069192e+00</second>
+						<second>4.68859685279093108e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.91915990374358558e+00</second>
+						<second>2.76412135399669312e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.09715175932831377e+00</second>
+						<second>-2.09712758285421508e+00</second>
 					</item>
 				</goal_state>
-				<score>1.77962710494763554e+00</score>
+				<score>1.21376034340722014e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -3759,37 +3759,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.91602374417966748e+00</second>
+						<second>-1.90958099538554094e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.96689212022231774e-01</second>
+						<second>-2.43666565468595708e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.56050796079096377e+00</second>
+						<second>1.56575123141125117e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.37611313566709503e-01</second>
+						<second>7.46592662792795347e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-4.56837785332447399e-01</second>
+						<second>-4.63069919211279990e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.40932585516797459e+00</second>
+						<second>7.39707771771725531e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75231397035650582e+00</second>
+						<second>1.75234416293205042e+00</second>
 					</item>
 				</goal_state>
-				<score>2.00462437098543633e+00</score>
+				<score>1.70692650666659590e-01</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -3849,34 +3849,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.08204811296656023e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.31623233763624903e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.19484582199539080e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.12039997208655118e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.85403592360446567e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.09823843757147266e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>9.23006879195151092e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -3939,34 +3939,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80936223138820074e+00</second>
+						<second>-1.56948545778394277e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-8.18157351707890723e-01</second>
+						<second>-1.04127421916719687e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.64704365904237804e+00</second>
+						<second>1.84501284393758946e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.71683304253661029e-01</second>
+						<second>2.05034845961364232e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.59089943524871957e+00</second>
+						<second>7.00222956828378651e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.36051824152801548e-01</second>
+						<second>-9.96675306066146516e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.75076284062963028e+00</second>
+						<second>-1.75068805264438243e+00</second>
 					</item>
 				</goal_state>
-				<score>2.61576370940917435e+00</score>
+				<score>1.56380532679752604e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4029,34 +4029,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.91683362271037372e+00</second>
+						<second>1.58530770840300672e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.74133310932165264e+00</second>
+						<second>1.60771401111398204e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.25611524772640415e-01</second>
+						<second>1.91974626016297134e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.87199025237881145e+00</second>
+						<second>2.47351695994398391e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.07072052509510796e-01</second>
+						<second>5.34923890927205603e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.38525901095120929e-01</second>
+						<second>-1.72481680768486889e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14345041642589562e+00</second>
+						<second>2.14343405328852077e+00</second>
 					</item>
 				</goal_state>
-				<score>1.12621523538947876e+00</score>
+				<score>1.00976776008641911e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4119,34 +4119,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.91681744481860949e+00</second>
+						<second>-1.46208466798958958e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.16047883513081418e+00</second>
+						<second>-2.32975367979295767e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.47714362103342944e+00</second>
+						<second>1.33343853997866479e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-4.97202889049760732e-01</second>
+						<second>9.02062668010661928e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.75259175642244802e+00</second>
+						<second>-1.02888300963649959e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.06292684541129434e+00</second>
+						<second>-2.53324952211125343e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.01887458082588456e+00</second>
+						<second>2.01890827743737855e+00</second>
 					</item>
 				</goal_state>
-				<score>1.01962233075368225e+00</score>
+				<score>1.28295938319610420e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4209,34 +4209,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.09620154082065557e+00</second>
+						<second>-1.32624569868331577e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.98375329317711313e+00</second>
+						<second>9.71851385242135102e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.91559557184099205e+00</second>
+						<second>-1.73801738231196090e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.40832245063025785e+00</second>
+						<second>1.25636732195214029e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.15690091847424936e+00</second>
+						<second>2.08613712596860879e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.98087400438522221e-01</second>
+						<second>7.38537461902544989e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70884723416629680e+00</second>
+						<second>1.70889010777371664e+00</second>
 					</item>
 				</goal_state>
-				<score>2.16363917186869026e+00</score>
+				<score>1.59030752488300453e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4299,34 +4299,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>4.08326642507211512e-01</second>
+						<second>-1.68716932853711876e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.54174126536737655e+00</second>
+						<second>1.54199363592272176e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91979981249692466e+00</second>
+						<second>1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.11422712604884189e-01</second>
+						<second>-6.89824347034822649e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.61387964598321343e+00</second>
+						<second>2.89325272607549977e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.19039311020277494e+00</second>
+						<second>1.36809497954129577e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.01047068608605883e+00</second>
+						<second>2.01032961949976530e+00</second>
 					</item>
 				</goal_state>
-				<score>1.20389165636935247e+00</score>
+				<score>1.23568782848675077e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4389,34 +4389,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.21300886886236725e+00</second>
+						<second>-1.90960329291406694e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>9.25358368089294947e-01</second>
+						<second>2.00205835707233470e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.42533148022140788e+00</second>
+						<second>-1.62097434864990886e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.12794353525002133e+00</second>
+						<second>2.58806840060137500e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.89877375670479909e+00</second>
+						<second>-2.90871838527884874e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.14254866666904209e-01</second>
+						<second>-1.10033164665614236e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.87149589629349333e+00</second>
+						<second>-1.87153159811868686e+00</second>
 					</item>
 				</goal_state>
-				<score>2.19656909145475421e+00</score>
+				<score>1.54870676585912109e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4479,34 +4479,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.53022189292809441e+00</second>
+						<second>1.83058207899806913e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>7.00453675309552048e-01</second>
+						<second>1.99865379783573061e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.53906782089154004e+00</second>
+						<second>1.85217768130687510e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.93747097344407226e+00</second>
+						<second>2.26398343345191089e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-9.97784685171257735e-01</second>
+						<second>2.21738754560527301e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.73398684683231485e-01</second>
+						<second>2.13442515175397984e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.55598097693302817e+00</second>
+						<second>1.55595552703473872e+00</second>
 					</item>
 				</goal_state>
-				<score>2.95411140116671467e+00</score>
+				<score>1.79756886744865091e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4569,34 +4569,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.18713183411074397e+00</second>
+						<second>-1.77943445874466466e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.38116181756341971e+00</second>
+						<second>-1.61464844311281253e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.08599553174845975e+00</second>
+						<second>-1.84029604630218513e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.05531775050922461e+00</second>
+						<second>-6.34740565533979284e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.29772050175647213e+00</second>
+						<second>-3.07294039114696949e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.97635756763170106e-02</second>
+						<second>1.39939324657310071e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.84173801460592257e+00</second>
+						<second>1.84180402278733624e+00</second>
 					</item>
 				</goal_state>
-				<score>2.22851116060931176e+00</score>
+				<score>1.53718868564325345e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4659,37 +4659,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.24617260256913687e+00</second>
+						<second>9.18470422532067121e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>8.19512907685954972e-01</second>
+						<second>-1.99765238835533232e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37429292922704893e+00</second>
+						<second>1.61137468030162823e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.27482608711207690e+00</second>
+						<second>-1.63894160383499643e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.88429844779066480e+00</second>
+						<second>-1.41573499130884173e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.65768377886834140e-01</second>
+						<second>-2.70793759661968325e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.65797191107991382e+00</second>
+						<second>1.65814711508908785e+00</second>
 					</item>
 				</goal_state>
-				<score>2.58109336219511309e+00</score>
+				<score>1.39753572231408024e-01</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -4749,34 +4749,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.90573765002441098e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.92584966039920835e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.87438042909369784e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-8.86654519634064275e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>3.11383355051859034e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.20074310117151617e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.27428268310425663e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>1.91137272270825304e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4839,34 +4839,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71002992049489233e+00</second>
+						<second>-1.80722623492579304e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.08732051146694753e+00</second>
+						<second>1.22064260874978370e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91921652080973271e+00</second>
+						<second>1.81378065970056790e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.26610703976341110e+00</second>
+						<second>-7.24250940944768384e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.74310944076803898e+00</second>
+						<second>-3.47418895793221549e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.01040111925714582e+00</second>
+						<second>1.22781581804138051e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44941722187336164e+00</second>
+						<second>1.44913774942550044e+00</second>
 					</item>
 				</goal_state>
-				<score>3.14754393971497981e+00</score>
+				<score>1.99706114320505612e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -4929,37 +4929,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.84582246476757161e+00</second>
+						<second>4.04135566818849878e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.72395355011903684e+00</second>
+						<second>-1.30827115277975436e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.83810554920398217e+00</second>
+						<second>-1.91979290562162963e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.29344276703311700e-01</second>
+						<second>3.03387419428623462e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.92071990593650588e+00</second>
+						<second>1.59067906790514080e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.25010227757585413e+00</second>
+						<second>2.52065248777097350e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49968478738721411e+00</second>
+						<second>-1.49958508245665922e+00</second>
 					</item>
 				</goal_state>
-				<score>3.03127993275650676e+00</score>
+				<score>1.61826939770637779e-01</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -5019,34 +5019,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.05565588453858927e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.34586101600182384e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.76908101842526455e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.22737622050536110e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.79037284653678408e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-8.74484813850403110e-04</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.13883187702551703e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>1.88333228794638707e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -5109,34 +5109,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85805360557982602e+00</second>
+						<second>-1.43867512137923592e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.75689468355472123e+00</second>
+						<second>1.36569603239886228e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64063811762531331e+00</second>
+						<second>-1.91949103973743562e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.94618515104317380e+00</second>
+						<second>2.20024637779115428e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.57506152855927795e-01</second>
+						<second>2.04794202812468296e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14149939473886430e+00</second>
+						<second>-5.34796856509308499e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.72739521482828651e-01</second>
+						<second>7.72808675404311529e-01</second>
 					</item>
 				</goal_state>
-				<score>2.59969201292127350e+00</score>
+				<score>1.60161564171403481e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -5199,34 +5199,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.70199994554933620e+00</second>
+						<second>-1.16173399823600620e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>8.86673637305314566e-01</second>
+						<second>8.85633226975815480e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.69065797251037164e+00</second>
+						<second>-1.12791195591770643e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.22100478856831218e+00</second>
+						<second>1.96596471210954804e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-7.12448246350560477e-01</second>
+						<second>1.76541193980158795e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.03931754589318626e+00</second>
+						<second>-2.27331445127750470e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.35092440724138330e-01</second>
+						<second>9.34963212913854758e-01</second>
 					</item>
 				</goal_state>
-				<score>2.74181647313376509e+00</score>
+				<score>1.73334345032280790e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -5289,34 +5289,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.53126048431065320e+00</second>
+						<second>-9.14294032941661672e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>9.32988447033313850e-02</second>
+						<second>-6.80207020728691880e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.02944222755326087e+00</second>
+						<second>1.91601641836829772e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.25986323797174271e+00</second>
+						<second>-2.34508987184577089e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.09080764483903891e+00</second>
+						<second>-1.30978447980787105e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.07439863789472442e-01</second>
+						<second>-1.09102783771801071e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.08041676943324627e+00</second>
+						<second>1.08033941434937120e+00</second>
 					</item>
 				</goal_state>
-				<score>2.95229916239696610e+00</score>
+				<score>1.81361428178618417e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -5379,34 +5379,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.68623338654639876e+00</second>
+						<second>-1.07910301885534032e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.13672185671777148e+00</second>
+						<second>1.11904590570472351e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.90077331538778260e+00</second>
+						<second>-1.46323656290360460e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.14255120062133653e+00</second>
+						<second>2.02212694563447615e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-5.12555647535357983e-01</second>
+						<second>1.76605332531941039e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.01148211768354956e+00</second>
+						<second>-1.36864602837754284e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.04538885910421775e+00</second>
+						<second>1.04556205913027989e+00</second>
 					</item>
 				</goal_state>
-				<score>2.83182944725968921e+00</score>
+				<score>1.86084196949639846e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -5469,34 +5469,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.91937228003343208e+00</second>
+						<second>-1.34513756682772900e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.63324595204770096e-01</second>
+						<second>-1.65897411243058235e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.55850303544677571e+00</second>
+						<second>1.80630873134083103e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.76985791397814207e+00</second>
+						<second>2.35971634721303669e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.42066654841103945e+00</second>
+						<second>-1.15910935645708202e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.72494421280343602e+00</second>
+						<second>-2.98876437952503793e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.40714610734937740e-01</second>
+						<second>6.41266853852858087e-01</second>
 					</item>
 				</goal_state>
-				<score>2.15705971834975507e+00</score>
+				<score>1.46016157527591978e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -5559,34 +5559,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.03204380807118445e+00</second>
+						<second>-1.03302792683224398e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.87609563009334002e+00</second>
+						<second>-1.88296273916221102e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.18618227320482417e+00</second>
+						<second>-1.18463387777199469e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-5.41766601815193427e-01</second>
+						<second>-5.49329337497494574e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.80812235120648124e+00</second>
+						<second>1.80865538864811071e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.49215971571159534e+00</second>
+						<second>1.49404714868263033e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-5.19108831883002164e-01</second>
+						<second>-5.19108635509427763e-01</second>
 					</item>
 				</goal_state>
-				<score>1.62177808256003808e+00</score>
+				<score>1.09983962249966663e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -5649,34 +5649,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>9.20944304263410118e-01</second>
+						<second>1.64183624552282681e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.87021193683798059e+00</second>
+						<second>-9.68553587956912709e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.23882836243211680e+00</second>
+						<second>-1.14208975351530451e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44358414718588746e+00</second>
+						<second>-2.63909976160415027e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.72050173624956004e+00</second>
+						<second>2.37868095041894634e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.38587727624378054e+00</second>
+						<second>-1.45783948125144103e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-7.90697043872218064e-01</second>
+						<second>7.90771426089265428e-01</second>
 					</item>
 				</goal_state>
-				<score>2.21201248455633959e+00</score>
+				<score>1.66809025070665889e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -5739,34 +5739,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.33909822773381015e+00</second>
+						<second>1.63405693256076834e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96700000000000008e+00</second>
+						<second>-7.33773541077750280e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.11318692844649303e+00</second>
+						<second>1.19912857499300229e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.32811088996762661e+00</second>
+						<second>5.89609898009325284e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.09987838825157969e+00</second>
+						<second>-7.77707656112554990e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11446869406191196e+00</second>
+						<second>-1.23350206514507077e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.44076017974224935e-01</second>
+						<second>-8.43199544348897545e-01</second>
 					</item>
 				</goal_state>
-				<score>2.62709874919048447e+00</score>
+				<score>1.78842253226124431e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -5829,34 +5829,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.07306076028477393e+00</second>
+						<second>-1.07439873849563283e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.30153318832618847e+00</second>
+						<second>2.28646573861164182e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.74242218219127443e+00</second>
+						<second>-1.85563179074018958e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.89685476727776159e+00</second>
+						<second>-2.87949410398669725e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.26330784971510068e+00</second>
+						<second>1.94060748867699040e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-6.39665768813404978e-01</second>
+						<second>-8.10233889531117524e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.32979355276173772e-01</second>
+						<second>6.32947804507358991e-01</second>
 					</item>
 				</goal_state>
-				<score>2.01923430819300753e+00</score>
+				<score>1.40614140499096624e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -7629,34 +7629,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.22261707897821226e+00</second>
+						<second>-1.21569085019979295e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.96989879832937675e+00</second>
+						<second>1.92608484427823146e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.14430782516393847e+00</second>
+						<second>-1.15295744911316000e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.82917973477982998e-01</second>
+						<second>6.38221749114839310e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.82984715897847505e+00</second>
+						<second>-1.82594863020504561e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.49996062094376925e+00</second>
+						<second>-1.49101962579820024e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.70365871962010684e-01</second>
+						<second>-4.70724754851056859e-01</second>
 					</item>
 				</goal_state>
-				<score>1.52984833760706862e+00</score>
+				<score>1.05550140029474812e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -7719,34 +7719,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.20072493153391280e+00</second>
+						<second>1.67806282313299904e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.29401653065134470e+00</second>
+						<second>-8.65300195557623830e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.07585158687137894e+00</second>
+						<second>1.55779019407507380e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.13214804831746640e+00</second>
+						<second>-2.27847314734681516e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.79407525989134164e+00</second>
+						<second>7.93358173574130410e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.83884112539327105e+00</second>
+						<second>2.01050122084273530e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-7.81838582683084482e-01</second>
+						<second>7.81700270650996232e-01</second>
 					</item>
 				</goal_state>
-				<score>2.19884513486316990e+00</score>
+				<score>1.73660215621569775e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -7899,34 +7899,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.33954212775196613e+00</second>
+						<second>1.41663424230316903e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.63776526730623795e+00</second>
+						<second>9.54391063497286862e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.56618297028304876e-01</second>
+						<second>7.08450683895690658e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.20026433140506272e+00</second>
+						<second>-8.33298855150977125e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.14176946023140680e+00</second>
+						<second>9.08015079001351255e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.04532254286535986e+00</second>
+						<second>2.09417599032144386e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.41290489080106318e-01</second>
+						<second>-4.41130728823186213e-01</second>
 					</item>
 				</goal_state>
-				<score>1.14608160239910362e+00</score>
+				<score>7.53807619890771857e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -7989,34 +7989,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-9.05568485194697237e-01</second>
+						<second>1.66668543165154537e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.03042734204526720e+00</second>
+						<second>2.24382878569000255e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.91043231349678377e-01</second>
+						<second>1.13909913005256613e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.80771688885842674e-01</second>
+						<second>3.76136595808350460e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.58617687811839780e+00</second>
+						<second>7.25033383772649032e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.32760428538130060e+00</second>
+						<second>2.36223533587272883e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.56682315444916354e-01</second>
+						<second>-8.56654139982709117e-01</second>
 					</item>
 				</goal_state>
-				<score>1.71898122911505813e+00</score>
+				<score>1.60343294990682395e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8079,34 +8079,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-7.29716014480253583e-01</second>
+						<second>-7.33184353003281997e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.72185443419870787e+00</second>
+						<second>1.73077418256617843e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.80495995855579805e-01</second>
+						<second>-8.76041098323675826e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.14503727789573051e-01</second>
+						<second>7.26812520068896073e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.47512954653220607e+00</second>
+						<second>-1.47602934986856305e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.49329031407886914e+00</second>
+						<second>-1.49921933305367761e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.08368232429619349e+00</second>
+						<second>-1.08369445152370347e+00</second>
 					</item>
 				</goal_state>
-				<score>2.05515147056394021e+00</score>
+				<score>1.32741714864621441e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8169,34 +8169,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-8.14320681441450644e-01</second>
+						<second>-9.98875651183726787e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.21401462915443181e+00</second>
+						<second>2.28640995113081180e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.13945459719185282e-01</second>
+						<second>-7.67820011894478238e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.10228191777270146e+00</second>
+						<second>1.35790724711182009e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.51821173322463743e+00</second>
+						<second>-1.63443583109530843e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.85256154446642274e+00</second>
+						<second>-1.94388962287790390e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.19611045330668420e+00</second>
+						<second>-1.19619227281900908e+00</second>
 					</item>
 				</goal_state>
-				<score>2.24990373148634282e+00</score>
+				<score>1.45817169728075319e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8259,34 +8259,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-7.45870603441779356e-01</second>
+						<second>-1.83740513819445717e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.46122563036105868e+00</second>
+						<second>9.20974068734324969e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.22974281249460882e+00</second>
+						<second>-9.57702996200852086e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.96985428048774280e-01</second>
+						<second>-6.42769027584327635e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.61046744129876673e+00</second>
+						<second>-2.53881165626981753e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.88590109267623518e+00</second>
+						<second>-1.85664847713948777e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.20883022743746338e+00</second>
+						<second>1.20883006971130746e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55008676467005557e+00</score>
+				<score>1.88011386760730315e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8349,34 +8349,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61769388841950512e+00</second>
+						<second>-6.72001854949631050e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.38848308169308821e+00</second>
+						<second>-1.46192144599300766e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91602565380586687e+00</second>
+						<second>1.36390410212980129e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.09383642848697082e+00</second>
+						<second>7.73097809363943789e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.53563760309345865e+00</second>
+						<second>1.60691308606509753e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.15840472683926254e+00</second>
+						<second>-2.12755169270514255e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32188649050487128e+00</second>
+						<second>-1.32182430600647538e+00</second>
 					</item>
 				</goal_state>
-				<score>3.19140182631580505e+00</score>
+				<score>1.66368935118395317e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8466,7 +8466,7 @@
 						<second>-9.66493235055629785e-01</second>
 					</item>
 				</goal_state>
-				<score>1.44793553589388080e+00</score>
+				<score>9.08662497803105762e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8529,34 +8529,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-6.74182730410798348e-01</second>
+						<second>-6.93796006308959656e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.79196342412904630e+00</second>
+						<second>1.83095560923705047e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-5.30852060755957256e-01</second>
+						<second>-5.12028238917678791e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.03057154185001587e+00</second>
+						<second>1.07282176014172403e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.33254130804008697e+00</second>
+						<second>-1.34180540025808437e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.45319834834764228e+00</second>
+						<second>-1.47087135607164687e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.22569891005392995e+00</second>
+						<second>-1.22565465742056756e+00</second>
 					</item>
 				</goal_state>
-				<score>1.33453264661056514e+00</score>
+				<score>8.26631997906027566e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8619,34 +8619,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78549015764916863e+00</second>
+						<second>3.02338804092033453e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.46293251880433717e+00</second>
+						<second>-1.86942576183234821e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.42800006654786760e+00</second>
+						<second>9.97637100460474935e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.65816357110755286e+00</second>
+						<second>-3.14149999974525196e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.23470045172304665e-01</second>
+						<second>1.80499682956014018e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.78735868478040705e-01</second>
+						<second>2.18201825955027973e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.44018062137717795e+00</second>
+						<second>-1.44019434816180869e+00</second>
 					</item>
 				</goal_state>
-				<score>2.59094867134576878e+00</score>
+				<score>1.37221524083871810e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8709,34 +8709,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.87095544990829432e+00</second>
+						<second>-1.62365900752708314e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-9.41636129794093502e-01</second>
+						<second>-1.92465997561880120e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.46963317388807901e+00</second>
+						<second>6.51575144644204518e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.82734144918757835e+00</second>
+						<second>-7.86082919365218347e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>3.43217179108098513e-01</second>
+						<second>2.16963791381195925e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.29524835396182381e+00</second>
+						<second>-1.80589814955066830e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.59140227951450308e+00</second>
+						<second>1.59161509363753795e+00</second>
 					</item>
 				</goal_state>
-				<score>1.13296452432284789e+00</score>
+				<score>1.29969351703113134e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8799,34 +8799,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.22329817303393540e+00</second>
+						<second>1.56410392327107162e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96699994562407987e+00</second>
+						<second>7.28295043384206919e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-5.19546296403588737e-01</second>
+						<second>6.17885731206998523e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.00045882051722002e+00</second>
+						<second>-8.69067931194239196e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.05507786343065835e+00</second>
+						<second>4.65495231400478049e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.35899340079208919e+00</second>
+						<second>1.00018852431569516e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.67180783864624405e+00</second>
+						<second>-1.67185165435976812e+00</second>
 					</item>
 				</goal_state>
-				<score>2.30800279555373189e+00</score>
+				<score>1.46536148407253874e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8889,34 +8889,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64310920712857378e+00</second>
+						<second>1.45280775481370444e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.79002321248350516e-01</second>
+						<second>1.32623066633258646e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>7.59438959086294552e-01</second>
+						<second>-1.64063532275902380e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.42961457148356019e-01</second>
+						<second>-3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.12549311102825622e-01</second>
+						<second>-1.47829308012362826e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.79013673728063072e-01</second>
+						<second>1.52525059516163397e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.67054708124365980e+00</second>
+						<second>-1.67056410361605279e+00</second>
 					</item>
 				</goal_state>
-				<score>2.59320688934108201e+00</score>
+				<score>1.49163936171487738e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -8979,34 +8979,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.81045719926727888e+00</second>
+						<second>-1.74415560521709723e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.30966527110286446e+00</second>
+						<second>-1.20627801622254971e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.83321275907042613e+00</second>
+						<second>1.91944628447769183e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.31035737771082572e-01</second>
+						<second>7.24721717031655777e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.51858015219994202e-01</second>
+						<second>1.81135482330360337e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.22188927357438826e+00</second>
+						<second>-1.13781331604679958e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70858620607624845e+00</second>
+						<second>1.70877505101669525e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55627350927667329e+00</score>
+				<score>1.71419638109928024e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9069,34 +9069,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59550989897317508e+00</second>
+						<second>-2.59582088406364375e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>-1.99984314652573492e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44090100690636991e+00</second>
+						<second>-8.41093207700901235e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.32744234516445747e-01</second>
+						<second>2.90542264992497667e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.36307827840030971e+00</second>
+						<second>-1.25474845524665923e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.20229958993756864e-02</second>
+						<second>-5.49430546647554086e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49983264729218946e+00</second>
+						<second>1.49984446626810985e+00</second>
 					</item>
 				</goal_state>
-				<score>2.99310541679632003e+00</score>
+				<score>1.16564403573069741e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9159,34 +9159,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72782590736430341e+00</second>
+						<second>-1.29252876934266814e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.78078938911414575e+00</second>
+						<second>-2.96699998908923757e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.55475685350429371e+00</second>
+						<second>1.60027403555939740e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48050623938856640e+00</second>
+						<second>-2.05851829218398530e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.56036164926105014e+00</second>
+						<second>1.05942826673441814e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.91482966344897543e+00</second>
+						<second>1.32634737615709208e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.66894884077853378e+00</second>
+						<second>-1.66884102302208537e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88441433023030269e+00</score>
+				<score>1.67442960213654651e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9249,34 +9249,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.40812025799538287e+00</second>
+						<second>1.55724838814644467e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.01258534261608313e+00</second>
+						<second>-1.97564221965999609e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-3.87057193789832221e-01</second>
+						<second>-1.19119727243353690e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-9.33084864326910846e-01</second>
+						<second>-2.02267562942432111e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-3.14016038200264802e+00</second>
+						<second>-1.36890672328097307e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.12122734852228412e+00</second>
+						<second>-2.24410487399629144e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.82014896173163843e+00</second>
+						<second>1.82032384013183690e+00</second>
 					</item>
 				</goal_state>
-				<score>1.35321854611362369e+00</score>
+				<score>5.20843980306336177e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9339,34 +9339,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-4.36985859436715252e-01</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.12979490990137910e+00</second>
+						<second>-1.05870337084088528e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.63789369143046737e+00</second>
+						<second>-1.59308712748763948e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.10813012386253051e+00</second>
+						<second>-2.87112120812761873e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.59615917663553630e+00</second>
+						<second>-3.06668113131099629e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.60188649476940470e-01</second>
+						<second>-9.66829310252059870e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.91471087568719067e+00</second>
+						<second>-1.91445717675176241e+00</second>
 					</item>
 				</goal_state>
-				<score>1.18088679828085308e+00</score>
+				<score>1.51597126951856509e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9429,34 +9429,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.32558736669130872e+00</second>
+						<second>1.31913585312937842e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96699999453984065e+00</second>
+						<second>2.95010183380505753e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>5.68357323096353118e-01</second>
+						<second>-5.69632949719796278e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.23876761409588498e+00</second>
+						<second>-9.05604259853654003e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.46789077008990620e-01</second>
+						<second>-2.18198304443915037e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.10476713008028127e-01</second>
+						<second>4.04890881177947193e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95027936317391948e+00</second>
+						<second>-1.95038172841708057e+00</second>
 					</item>
 				</goal_state>
-				<score>2.02700329454815265e+00</score>
+				<score>1.27042606835563149e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9519,34 +9519,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.79623416942807174e-01</second>
+						<second>-1.41484505582021947e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.29821330892276876e+00</second>
+						<second>2.86802985855351000e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91979999999999995e+00</second>
+						<second>-7.70932121277332127e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.80594517259085263e-01</second>
+						<second>2.25574921258826766e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.55443520857217576e+00</second>
+						<second>-2.16210204741205603e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.07833171537881389e+00</second>
+						<second>-2.93176700418447478e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.92768107520861731e+00</second>
+						<second>-1.92776800847500729e+00</second>
 					</item>
 				</goal_state>
-				<score>1.76470841609541473e+00</score>
+				<score>1.39130594175575689e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9609,34 +9609,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85619869990131159e+00</second>
+						<second>-1.77815116686493502e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-9.08288838404546217e-01</second>
+						<second>2.87671728343350264e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.82127054171012870e-01</second>
+						<second>-1.43370101909979542e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-4.27374566062601602e-01</second>
+						<second>5.83954684841631821e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.57238206135825814e-01</second>
+						<second>-2.60717139581401325e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.03951202183683988e+00</second>
+						<second>-9.20091045913934980e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68217647170056561e+00</second>
+						<second>1.68214978546571925e+00</second>
 					</item>
 				</goal_state>
-				<score>8.90812168949856487e-01</score>
+				<score>1.74600624265473819e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9699,34 +9699,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>9.79811942823496373e-02</second>
+						<second>5.91859180969590781e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.14465271371399457e+00</second>
+						<second>1.26434201622114939e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.01047896702943873e-01</second>
+						<second>2.62495063429076525e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.40055771767694681e-01</second>
+						<second>1.90000240357351036e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.12618049584993907e+00</second>
+						<second>2.37169228584787151e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.16558072854845147e-03</second>
+						<second>9.71128483894627026e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.84012434428012961e+00</second>
+						<second>1.84035524961431562e+00</second>
 					</item>
 				</goal_state>
-				<score>1.05705610778155812e+00</score>
+				<score>2.32398797873038451e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9789,37 +9789,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.06324610983759960e+00</second>
+						<second>-3.90523658827669429e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.37494219794812711e+00</second>
+						<second>1.38704434714152680e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.92003509174638942e-02</second>
+						<second>-6.75046775402097121e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.18196382972099423e+00</second>
+						<second>2.42773649606133191e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-3.13295584056993315e+00</second>
+						<second>-1.20663950480828275e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.27541616235289768e+00</second>
+						<second>-3.11877371016853511e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.99562017148508697e+00</second>
+						<second>-1.99581409643158869e+00</second>
 					</item>
 				</goal_state>
-				<score>1.07888264301256531e+00</score>
+				<score>5.35192614305476308e-02</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -9879,34 +9879,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.91954965562301427e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.24864831415738053e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.27533191640245525e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.96627793130556006e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.85979687064959487e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.38829446237082843e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.10133621053898700e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>1.12556105656962280e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -9969,37 +9969,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85946368749034785e+00</second>
+						<second>1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.79791751606199601e+00</second>
+						<second>1.67845647397486486e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.97362366978549297e-01</second>
+						<second>-1.42429216334133701e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.97620335507399969e-01</second>
+						<second>-3.07843013677915067e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.52947768250495753e-01</second>
+						<second>2.86178010965078888e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.01323689057388489e+00</second>
+						<second>1.65229048861611427e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14038682548266790e+00</second>
+						<second>2.14022171868786959e+00</second>
 					</item>
 				</goal_state>
-				<score>8.18727507093685247e-01</score>
+				<score>1.11393096810486439e-01</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -10059,37 +10059,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.91963939798422611e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.17784483887565106e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.01384664911208278e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.16285370080214173e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>3.04879791409343381e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>8.40416176906404244e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.10508197310576506e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>1.10684607860396966e-01</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -10149,37 +10149,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.74969210823702348e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.17728184097418609e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-4.45268502633317409e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-5.46870906604342455e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-8.58801372690314868e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.96453725065436835e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.96577845113265415e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>4.30578576968635718e-02</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -10239,34 +10239,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-7.19675308126737634e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.46819731732562819e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>3.00531980163712653e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.86513219715781720e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-8.18320098136314122e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.12698204251834833e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>1.13018353167999769e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -10329,34 +10329,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.08093954996353103e+00</second>
+						<second>-8.93148490691796582e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.64439512907512964e-01</second>
+						<second>-1.33273369757269178e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.26644433724732525e-01</second>
+						<second>-3.65656325646051050e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.55676875357525102e+00</second>
+						<second>-4.85015510760622715e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.51015257952807280e+00</second>
+						<second>-1.54084997258108070e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.74704054822603494e-01</second>
+						<second>-3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.24543665752652544e+00</second>
+						<second>2.24542997705025815e+00</second>
 					</item>
 				</goal_state>
-				<score>1.08406984480563962e+00</score>
+				<score>3.40594263768660838e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -10509,34 +10509,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-7.25077092712950733e-01</second>
+						<second>1.06785510410117745e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.69790623811153374e+00</second>
+						<second>-1.25801495672372798e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.91979933927995750e+00</second>
+						<second>1.31289200516547555e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.83516551080971357e+00</second>
+						<second>-6.18514395774587333e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.37221475720566621e+00</second>
+						<second>1.31646239459355030e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.41926314378292839e+00</second>
+						<second>-8.97979130634647293e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23615670605478734e+00</second>
+						<second>-2.23627826066633117e+00</second>
 					</item>
 				</goal_state>
-				<score>1.21471623246569083e+00</score>
+				<score>8.20193529436702151e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -10599,34 +10599,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.24400858352781674e+00</second>
+						<second>8.64494678852957388e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.00794230163967313e+00</second>
+						<second>1.65994422402802777e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.42386606328526266e+00</second>
+						<second>-1.89691063546972472e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.32960376327118968e-01</second>
+						<second>-6.75194655226710183e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.16492286900340658e+00</second>
+						<second>-1.85019794974924978e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20209079998456358e+00</second>
+						<second>-1.44003281866638178e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19642123860076621e+00</second>
+						<second>-2.19636594032453791e+00</second>
 					</item>
 				</goal_state>
-				<score>1.49011833835805363e+00</score>
+				<score>7.75173700369607838e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -10689,34 +10689,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.60477486426728588e+00</second>
+						<second>-1.81193939407573379e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.42027186015603257e-01</second>
+						<second>-2.92154989143107047e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.40048434285221357e+00</second>
+						<second>-1.50590309321903115e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.45756920258562817e+00</second>
+						<second>4.70755390375492966e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.90548734895434202e-01</second>
+						<second>-2.65747215491082756e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.38153555537676764e+00</second>
+						<second>4.42412874020372160e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.05338397701281306e+00</second>
+						<second>2.05337440020833029e+00</second>
 					</item>
 				</goal_state>
-				<score>1.87313164443909197e+00</score>
+				<score>1.24023105413048867e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -10779,34 +10779,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>6.32648198216742008e-01</second>
+						<second>-1.36631289535410794e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.35593419478090071e-01</second>
+						<second>7.21452197847427645e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75477249834014554e-01</second>
+						<second>-1.38539706021723585e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.39537372196105464e-01</second>
+						<second>-2.48556036488258014e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.10942681408811533e-01</second>
+						<second>-2.10118530113150603e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.56848364001422352e-01</second>
+						<second>1.07669798252642068e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.19775669842247146e+00</second>
+						<second>-2.19775159138125176e+00</second>
 					</item>
 				</goal_state>
-				<score>6.95799304744568858e-01</score>
+				<score>9.10874188554177816e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -11139,34 +11139,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76528754992648396e+00</second>
+						<second>-1.91354665631722276e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.19171237454950285e+00</second>
+						<second>-2.96699999995778052e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.25108377829169792e+00</second>
+						<second>-8.96393682147945237e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.72491677711839975e+00</second>
+						<second>3.10054798745581417e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.49193012835087568e+00</second>
+						<second>3.10864320689869533e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.23265224736698809e+00</second>
+						<second>-3.00111627484888466e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23355126590407460e+00</second>
+						<second>-2.23354722754471968e+00</second>
 					</item>
 				</goal_state>
-				<score>1.50718223248924810e+00</score>
+				<score>9.64923647314701038e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -11229,37 +11229,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-4.12536375348701467e-01</second>
+						<second>-1.27873567575984626e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.35354436364568367e-02</second>
+						<second>2.47710668430121883e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>2.62672116812931677e-01</second>
+						<second>1.18929109354979556e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.03023106022121191e-01</second>
+						<second>2.28977175625188645e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.99103945834313301e+00</second>
+						<second>-1.14175854138116017e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.65645996643270310e+00</second>
+						<second>-1.09389538625354366e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.05199243548849442e+00</second>
+						<second>-2.05200514818939705e+00</second>
 					</item>
 				</goal_state>
-				<score>6.52257570380298746e-01</score>
+				<score>1.01475883590154400e-01</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -11319,34 +11319,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-6.08263209734469679e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-9.29626075983357669e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-3.22245690465838674e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>3.09565693715111356e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>9.89000992610836405e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.83672101615901173e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.19860873141681878e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>3.42573197458702003e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -11679,37 +11679,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81878511637749329e+00</second>
+						<second>1.65013210688882861e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.23695875169699032e-01</second>
+						<second>-2.31694051368284759e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.46439707977363764e-01</second>
+						<second>-1.14653788479336893e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.42563015188256659e-01</second>
+						<second>5.26067031623922432e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-4.80643119460821555e-01</second>
+						<second>2.34326323075837450e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.45171057621394994e-01</second>
+						<second>7.08940845644437156e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23337729625187453e+00</second>
+						<second>-2.23337613612980723e+00</second>
 					</item>
 				</goal_state>
-				<score>1.52375655115017827e+00</score>
+				<score>9.34557958458304971e-02</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -11769,34 +11769,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.65858407908080241e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>8.92083438242579962e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-9.43469105369530991e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.45436134804771067e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.49171206355138075e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.31629473956881093e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.96937768095318599e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>1.05575581409331945e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -11859,34 +11859,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91469592883001671e+00</second>
+						<second>-6.37634835167808167e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.66598987233964246e+00</second>
+						<second>1.93726537176498614e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.65696630181241367e+00</second>
+						<second>2.72244400867128589e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.62915004955622750e-01</second>
+						<second>-2.52668040219127299e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>3.14149923267086484e+00</second>
+						<second>-2.22861172140119779e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.09653242547718455e-01</second>
+						<second>2.84355346570767997e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.12629894014469034e+00</second>
+						<second>-2.12629623825455649e+00</second>
 					</item>
 				</goal_state>
-				<score>6.52315867476578992e-01</score>
+				<score>2.57363374380153095e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -11949,34 +11949,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.78251176099799391e+00</second>
+						<second>-7.28746052527798893e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.19489238988229673e+00</second>
+						<second>1.87853365741573186e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.24313199455754897e+00</second>
+						<second>1.12820793985817192e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.85906965658484014e+00</second>
+						<second>2.95665303167637505e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.71302138200440068e-01</second>
+						<second>-1.56436361274878277e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.67606665185651682e+00</second>
+						<second>-1.86026274200290720e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.24598222712090623e+00</second>
+						<second>-2.24597732206022727e+00</second>
 					</item>
 				</goal_state>
-				<score>1.36893879494514903e+00</score>
+				<score>7.23725837765652330e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -12129,34 +12129,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.82144546480838221e+00</second>
+						<second>1.59313503189602845e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.57843304201246459e+00</second>
+						<second>-1.69628142610427513e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.99837885856917397e-01</second>
+						<second>-1.91680147424322467e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.66030430629205894e-01</second>
+						<second>2.61772207761220654e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-3.10585614454091274e+00</second>
+						<second>-2.60463664898788938e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.35230579294670794e-01</second>
+						<second>-1.88484402445410248e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23426143576271397e+00</second>
+						<second>2.23431833011695469e+00</second>
 					</item>
 				</goal_state>
-				<score>1.42604841400662385e+00</score>
+				<score>8.82884568440329975e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -12219,34 +12219,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74851762123866439e+00</second>
+						<second>1.41442981248844735e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.44848180349166256e-01</second>
+						<second>-2.20450455837848169e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.18977104702790148e-01</second>
+						<second>-1.22366471950318756e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>4.88784524483641847e-01</second>
+						<second>6.97502391514736697e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.54724794725825099e+00</second>
+						<second>2.09155854639323291e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.90066797114521879e+00</second>
+						<second>7.24214781020509957e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19434632166903887e+00</second>
+						<second>-2.19435197737582799e+00</second>
 					</item>
 				</goal_state>
-				<score>1.64272314118825014e+00</score>
+				<score>9.69754021104456132e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -12309,34 +12309,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>3.02999424606095191e-01</second>
+						<second>-1.01326829005136843e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.21116522803929483e+00</second>
+						<second>-1.12067210043157739e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>4.91146657947240883e-01</second>
+						<second>-6.71156193980066651e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.39187157337104894e+00</second>
+						<second>-6.12889555935284824e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.18050830717761990e+00</second>
+						<second>1.10118764456380180e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.31464350069013070e+00</second>
+						<second>1.21090180633208755e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68375817095982816e+00</second>
+						<second>-1.68402349625422953e+00</second>
 					</item>
 				</goal_state>
-				<score>4.60724348181056287e-01</score>
+				<score>7.52060646342178063e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -12399,37 +12399,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73640932235893741e+00</second>
+						<second>-7.56930571186441303e-02</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96310799106575162e+00</second>
+						<second>2.02107621143396310e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.57358260983191656e+00</second>
+						<second>7.49712316407612822e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.49928128043647169e+00</second>
+						<second>3.14002884087630729e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.57746392793297119e+00</second>
+						<second>-1.98120707632235171e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.13778823383798322e+00</second>
+						<second>-2.46192854485774104e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.83803655257394549e+00</second>
+						<second>-1.83818434877199532e+00</second>
 					</item>
 				</goal_state>
-				<score>2.53933438727767591e+00</score>
+				<score>8.83331818906923638e-02</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -12489,34 +12489,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.23237501315980968e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-3.54620303306901752e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.76130367485426986e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-9.11888319037159056e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.06357000906045096e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-3.78401259382116772e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.99621870173075222e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>1.25594302793533369e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -12579,34 +12579,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.86306013661689018e+00</second>
+						<second>4.76319936329718419e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.31555036379148182e+00</second>
+						<second>-1.19098746562054481e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.76620201265967802e+00</second>
+						<second>1.36965674982860142e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.34746571828046957e-01</second>
+						<second>2.76712840153663198e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>3.14150000000000018e+00</second>
+						<second>-1.63699851336849633e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.01251336101051170e-01</second>
+						<second>1.68160364519812755e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.10305986174241832e+00</second>
+						<second>2.10300037800152761e+00</second>
 					</item>
 				</goal_state>
-				<score>1.07484775167085500e+00</score>
+				<score>9.08684071036614804e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -12669,34 +12669,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979999999999995e+00</second>
+						<second>-1.08539423427525006e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.45520909706309198e+00</second>
+						<second>8.61537369439154821e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.42561763890709092e+00</second>
+						<second>-6.26043473133586659e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.08079006401035649e+00</second>
+						<second>7.72291005647210871e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.86150675388135323e+00</second>
+						<second>1.81159874146591493e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.48195571929522618e+00</second>
+						<second>3.14149998925034790e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.14088621192486928e+00</second>
+						<second>2.14108172134403452e+00</second>
 					</item>
 				</goal_state>
-				<score>7.11054609667531978e-01</score>
+				<score>7.82233373066738291e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -12759,37 +12759,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>6.10393588345254701e-01</second>
+						<second>-1.53940509389187485e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.65612469265564077e+00</second>
+						<second>-2.96699983362994191e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.56689847327008436e+00</second>
+						<second>-7.28028494856122421e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.44881187582345428e+00</second>
+						<second>-2.44044195298076749e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.54030338323398097e+00</second>
+						<second>2.37706164606892978e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>9.90944161727414397e-01</second>
+						<second>3.03977365621249795e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.09843802742846375e+00</second>
+						<second>-2.09849533286608692e+00</second>
 					</item>
 				</goal_state>
-				<score>1.34465343350406452e+00</score>
+				<score>1.15858407452903572e-01</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -12849,34 +12849,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.89510720825773871e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>8.20166808459961927e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.14001675094590160e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.24081376720707881e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.39592360708038887e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.49550403615448713e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>1.76437646225977962e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -12939,34 +12939,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.47334217786541072e-01</second>
+						<second>9.94619382566480775e-02</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.27446970301488660e+00</second>
+						<second>1.93851141135637883e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.09717177215068751e-01</second>
+						<second>8.95208115206114874e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.73292652011883552e-01</second>
+						<second>3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.20971240044646478e+00</second>
+						<second>-1.89272389736489122e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.63641767018996598e+00</second>
+						<second>-2.30324682201052422e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.66854555579049957e+00</second>
+						<second>-1.66834262335663341e+00</second>
 					</item>
 				</goal_state>
-				<score>1.15973667927079260e+00</score>
+				<score>1.14529867076122963e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -13029,37 +13029,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.17537219334189244e-01</second>
+						<second>1.52268761347009907e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.33225099638150302e+00</second>
+						<second>-2.96700000000000008e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.89898807131624037e-01</second>
+						<second>1.82323755462498927e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.18256854455601079e+00</second>
+						<second>-8.48734771308687241e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.84794542458285771e+00</second>
+						<second>-7.26873500477052903e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.17165088847298075e-03</second>
+						<second>-3.01440447708792503e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82322472617352060e+00</second>
+						<second>-1.82325535187891474e+00</second>
 					</item>
 				</goal_state>
-				<score>9.80025407988013741e-01</score>
+				<score>1.63515187906296378e-01</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -13119,34 +13119,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.18188280491858633e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.62643150805662884e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>3.57020807528988571e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>9.86977864860817955e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-9.76103814558812011e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-6.51524736414368255e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.91959951534749251e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>1.15752305031832828e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -13209,34 +13209,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.05721340791645391e+00</second>
+						<second>1.91808962022204144e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>7.64615886293791847e-01</second>
+						<second>-1.78495953934318163e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.94753847444241845e-01</second>
+						<second>1.59202968425833880e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.14604589264162104e+00</second>
+						<second>-2.67917477364161771e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.76977077355334411e+00</second>
+						<second>3.91186252751355643e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.03046174609780583e-01</second>
+						<second>-1.86858356532876901e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95456772673586676e+00</second>
+						<second>-1.95454526197590872e+00</second>
 					</item>
 				</goal_state>
-				<score>1.64875130428336081e+00</score>
+				<score>1.44780440541412564e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -13299,34 +13299,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.05415414840773258e+00</second>
+						<second>-1.55679972493913787e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>8.68286993160049647e-01</second>
+						<second>-3.89143430138045032e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.80312776913066397e-01</second>
+						<second>7.56896539222629006e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.04588550235985500e+00</second>
+						<second>-2.34479402989801722e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.75180910224192932e+00</second>
+						<second>-7.49133881123653311e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.09555641718059560e+00</second>
+						<second>2.80128117757389594e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91966717825427602e+00</second>
+						<second>-1.91967421254401738e+00</second>
 					</item>
 				</goal_state>
-				<score>1.85747025971997504e+00</score>
+				<score>1.44695418360053674e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -13389,34 +13389,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-8.15516339766840903e-01</second>
+						<second>-7.80876007578384046e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.96233849642378311e+00</second>
+						<second>-1.85523693841815107e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-5.32248616941976782e-01</second>
+						<second>-5.69839736104229111e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-9.02535019099150793e-01</second>
+						<second>-7.89958494626751051e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.48961589434438424e+00</second>
+						<second>1.46447872044036309e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.22914310352359379e+00</second>
+						<second>1.18623059279350307e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.49982184898873983e-01</second>
+						<second>-9.49808739131742685e-01</second>
 					</item>
 				</goal_state>
-				<score>1.45194105736802337e+00</score>
+				<score>9.28938018289974660e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -13506,7 +13506,7 @@
 						<second>-1.22673386703047549e+00</second>
 					</item>
 				</goal_state>
-				<score>1.34156517519893592e+00</score>
+				<score>8.39987522698944916e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -13569,34 +13569,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-7.34683106325378366e-01</second>
+						<second>1.26979008618239608e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.45080340402996599e+00</second>
+						<second>2.59023575823201258e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.42302492641022194e+00</second>
+						<second>3.32767123522771546e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.69475089787046751e+00</second>
+						<second>-1.95625147724393944e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.63511101101506995e+00</second>
+						<second>-6.07836778098379993e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.07067376882463416e-02</second>
+						<second>-1.34497749929566313e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44352668438038667e+00</second>
+						<second>1.44347966688744811e+00</second>
 					</item>
 				</goal_state>
-				<score>2.11957053164731235e+00</score>
+				<score>1.29161861963516228e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -13659,34 +13659,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.82811590160520149e-01</second>
+						<second>-9.09185274194105220e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.22211893834976681e+00</second>
+						<second>7.81176037679793600e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.23735562482829686e+00</second>
+						<second>4.67955243724345105e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.78322918217369475e-01</second>
+						<second>-1.76679984186489336e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.75570349305915130e+00</second>
+						<second>-1.53321691739804855e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.52581470086365423e+00</second>
+						<second>2.19986287836472760e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.60006610246032666e+00</second>
+						<second>-1.60020554373109802e+00</second>
 					</item>
 				</goal_state>
-				<score>1.98728467407406151e+00</score>
+				<score>1.04023244001314116e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -13749,34 +13749,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.88894948610890689e+00</second>
+						<second>-1.78685482128418682e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.47291741641090090e+00</second>
+						<second>1.90583394509898540e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.04875410507604117e+00</second>
+						<second>-8.58932643549926711e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.51210569581088206e-01</second>
+						<second>-2.56309194036850618e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.98090273040947062e+00</second>
+						<second>2.92984084022015168e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.67231445101913789e+00</second>
+						<second>1.88240878980698279e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68114663753351978e+00</second>
+						<second>-1.68114010341298670e+00</second>
 					</item>
 				</goal_state>
-				<score>8.13935591314412288e-01</score>
+				<score>1.47987085635851556e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -13839,34 +13839,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77159396684215165e+00</second>
+						<second>-4.92726520822158676e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.06866063004510403e+00</second>
+						<second>1.39458506390257164e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84760431402057868e+00</second>
+						<second>1.24922911175094908e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46842125570228710e+00</second>
+						<second>-1.47510477068907542e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.86178733134676078e+00</second>
+						<second>-1.67842635597362277e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13831245581663687e+00</second>
+						<second>2.76854873314190009e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68223409075481634e+00</second>
+						<second>-1.68209640158615636e+00</second>
 					</item>
 				</goal_state>
-				<score>2.77506490340637679e+00</score>
+				<score>8.42627749342339805e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -13929,34 +13929,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.43531533341674100e+00</second>
+						<second>-1.90516134897439904e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96699999895045297e+00</second>
+						<second>1.68060943915265315e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.24161438423364756e-01</second>
+						<second>-1.69376643395135895e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.02495383146078023e+00</second>
+						<second>2.12000342266492670e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.13502663847101504e+00</second>
+						<second>1.49441679858012466e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.17552425847183606e-01</second>
+						<second>2.72163579151981017e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.71099402716718441e+00</second>
+						<second>1.71112231508997437e+00</second>
 					</item>
 				</goal_state>
-				<score>2.65120303324593865e+00</score>
+				<score>8.64468562418860414e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -14109,34 +14109,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.20745073150342641e+00</second>
+						<second>1.42867811848731407e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.13032902988282702e-01</second>
+						<second>-1.06393717277232502e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.46000430311595153e-01</second>
+						<second>7.29170084585394451e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.76351007765264889e+00</second>
+						<second>7.34369355204979590e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.95414486358020634e+00</second>
+						<second>-9.00399275037825575e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.09953861589609536e+00</second>
+						<second>-2.11803291157831852e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.26303072667013672e-01</second>
+						<second>-4.26367388105410194e-01</second>
 					</item>
 				</goal_state>
-				<score>1.08375260986259425e+00</score>
+				<score>7.38037678318853724e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -14226,7 +14226,7 @@
 						<second>-8.50023767214708625e-01</second>
 					</item>
 				</goal_state>
-				<score>1.72899999903284129e+00</score>
+				<score>1.11924565096935422e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -14316,7 +14316,7 @@
 						<second>-1.07734173969160318e+00</second>
 					</item>
 				</goal_state>
-				<score>2.05627177806386241e+00</score>
+				<score>1.33068315621161143e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -14379,34 +14379,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-6.50764850372115289e-01</second>
+						<second>1.65610144699403161e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.12224267863576088e+00</second>
+						<second>-2.47873223360429185e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.44014993514386958e+00</second>
+						<second>-1.60192563925322151e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.45367801645884165e-01</second>
+						<second>2.28068732685576858e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.56653484220546546e+00</second>
+						<second>2.42068416980739709e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>9.29569494602203616e-01</second>
+						<second>-2.37919144432059504e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.18864726815016164e+00</second>
+						<second>1.18830519406464119e+00</second>
 					</item>
 				</goal_state>
-				<score>2.73133918641017948e+00</score>
+				<score>2.06952083450159668e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -14469,34 +14469,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.09644641267873744e+00</second>
+						<second>8.83285758388098974e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.90709143515057900e+00</second>
+						<second>-1.96831707128391087e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.88007332498985003e+00</second>
+						<second>1.06351567069343989e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.41207580126073617e+00</second>
+						<second>-1.07634479742875122e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.97008951184641012e+00</second>
+						<second>-1.57084700479688544e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.36471025539712709e+00</second>
+						<second>-1.07651633782165201e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22481227975414475e+00</second>
+						<second>1.22481144738791170e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88153760331429387e+00</score>
+				<score>1.60667569867397220e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -14559,34 +14559,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>5.68177011246680075e-01</second>
+						<second>-7.28932192314334482e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.46705570330263479e+00</second>
+						<second>2.38717730217034418e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.50496966648867381e+00</second>
+						<second>1.91390364583059847e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.75612215870060329e+00</second>
+						<second>9.46451112124448879e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.53083553538697004e+00</second>
+						<second>-1.40823367885027317e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.25873611394319540e+00</second>
+						<second>1.02031237213084869e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.32825124744527723e+00</second>
+						<second>-1.32808081349913998e+00</second>
 					</item>
 				</goal_state>
-				<score>2.76747091606945883e+00</score>
+				<score>1.63740087821277358e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -15189,34 +15189,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.21582257237958324e+00</second>
+						<second>-1.21725363418362287e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.96898441475584685e+00</second>
+						<second>-1.97793196437586771e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.14266424884882389e+00</second>
+						<second>-1.14089038884249838e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.83193232414699758e-01</second>
+						<second>-6.92353287654139948e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.82628823406813323e+00</second>
+						<second>1.82712073228523031e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.50212871056501318e+00</second>
+						<second>1.50397958731362125e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.78444509154321407e-01</second>
+						<second>-4.78439556871023797e-01</second>
 					</item>
 				</goal_state>
-				<score>1.55624495744348335e+00</score>
+				<score>1.06724588015405741e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -15279,34 +15279,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.11667008859073280e+00</second>
+						<second>-1.82394511134184745e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.05267552672379683e+00</second>
+						<second>1.59883936209401067e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.14334940209197855e+00</second>
+						<second>1.30196104382341304e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.24296277159568813e+00</second>
+						<second>-8.20019870989767280e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.40026690323890368e+00</second>
+						<second>-7.00139562927242887e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.78704396574746771e+00</second>
+						<second>1.41987022414009245e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.85440494025856029e-01</second>
+						<second>7.85580371880156503e-01</second>
 					</item>
 				</goal_state>
-				<score>2.20534704087316991e+00</score>
+				<score>1.70301138906584854e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -17169,34 +17169,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.02239393200333573e+00</second>
+						<second>-1.33575716820261947e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.09675499208434424e+00</second>
+						<second>7.06127530070839171e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>6.60752843186195760e-01</second>
+						<second>-6.05776778527956972e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.56137765089082547e+00</second>
+						<second>-1.10636453308175597e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.38704429811137997e+00</second>
+						<second>-2.21719570046094017e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.21347834869695603e+00</second>
+						<second>-1.01939629321884717e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.56078498803381693e-01</second>
+						<second>4.56024916697949756e-01</second>
 					</item>
 				</goal_state>
-				<score>1.06704945248320615e+00</score>
+				<score>7.04086783025771323e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -17529,34 +17529,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36900613459642884e+00</second>
+						<second>-1.36868237237873669e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.10054277472041995e+00</second>
+						<second>1.09870241476746688e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>5.30678754922522256e-01</second>
+						<second>5.30364901983272463e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.23149765602646122e+00</second>
+						<second>2.22997403861568921e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.62751067478911082e-01</second>
+						<second>7.63050578799813306e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.67112741878443671e-01</second>
+						<second>-8.67445348706556096e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.69185498819668423e-01</second>
+						<second>-4.69196745664701986e-01</second>
 					</item>
 				</goal_state>
-				<score>9.90334509156620690e-01</score>
+				<score>6.21974315556202834e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -17646,7 +17646,7 @@
 						<second>-9.53265930081534374e-01</second>
 					</item>
 				</goal_state>
-				<score>1.29321995058293049e+00</score>
+				<score>8.11832485201464532e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -17736,7 +17736,7 @@
 						<second>-1.22304121682652300e+00</second>
 					</item>
 				</goal_state>
-				<score>1.14620276667101928e+00</score>
+				<score>7.19395510664150861e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -17979,34 +17979,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.31222720248733404e+00</second>
+						<second>-1.31341564281347400e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.27939713425300061e+00</second>
+						<second>1.28291005097738453e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>3.13593709603682047e-01</second>
+						<second>3.14631013517095715e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.93065620454844744e+00</second>
+						<second>1.93305021874233551e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.31516491632137417e-01</second>
+						<second>2.30584436676373600e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.00115465142979798e+00</second>
+						<second>-1.00063064708380889e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.52424988756112945e-01</second>
+						<second>-8.52362519781742267e-01</second>
 					</item>
 				</goal_state>
-				<score>1.01911012761702491e+00</score>
+				<score>6.39324381228705552e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -18069,34 +18069,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-6.93015849970589293e-01</second>
+						<second>-6.69572195672667236e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.63611118933013211e+00</second>
+						<second>1.59566711796338079e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-3.07887615264888170e-01</second>
+						<second>-3.30898447449857247e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.08522303449456614e+00</second>
+						<second>1.03420844799089862e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.12147732571719350e+00</second>
+						<second>-1.11816080416488828e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.25336329748358732e+00</second>
+						<second>-1.23229104658783517e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.21418603397266978e+00</second>
+						<second>-1.21414559683452183e+00</second>
 					</item>
 				</goal_state>
-				<score>7.70497660753122871e-01</score>
+				<score>5.04744323033260583e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -18159,34 +18159,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-6.00729730701534459e-01</second>
+						<second>-4.41376246051826238e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.52926993072476214e+00</second>
+						<second>1.36520657641026433e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-3.55109522760630569e-01</second>
+						<second>-5.08242549674962185e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.24550351963730610e+00</second>
+						<second>9.13853049729421052e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.04228057592113643e+00</second>
+						<second>-1.08765952088478568e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.52207577790875392e+00</second>
+						<second>-1.35161082698479951e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.42467377967943376e+00</second>
+						<second>-1.42470573906227327e+00</second>
 					</item>
 				</goal_state>
-				<score>7.08426971080675205e-01</score>
+				<score>6.32423090565556040e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -18339,34 +18339,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.20844229047349394e+00</second>
+						<second>-1.20903792684814859e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.17851646990905312e+00</second>
+						<second>1.18124911941269040e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>2.27675825883978167e-01</second>
+						<second>2.28150013739029295e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.67270972823862119e+00</second>
+						<second>1.67454394614623414e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.09966975277338624e-01</second>
+						<second>2.09105149256740036e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-6.82664612132685589e-01</second>
+						<second>-6.82588394506945528e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-5.74659886955450006e-01</second>
+						<second>-5.74653628714996478e-01</second>
 					</item>
 				</goal_state>
-				<score>5.86601011777236336e-01</score>
+				<score>3.67715315927480066e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -18429,34 +18429,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-8.37960827949974507e-01</second>
+						<second>-5.89876758663438694e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.31062863973702060e+00</second>
+						<second>1.14059773354916549e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.76637217101560690e-02</second>
+						<second>-3.93378252060362421e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.16383159835139471e+00</second>
+						<second>1.68614340240252264e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.06724831813058252e-01</second>
+						<second>-1.10655415301983640e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-9.66799404096459147e-01</second>
+						<second>-4.94165202250531566e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.04797774705633229e+00</second>
+						<second>-1.04779391153479740e+00</second>
 					</item>
 				</goal_state>
-				<score>2.62494227858325380e-01</score>
+				<score>6.14463837292906490e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -18546,7 +18546,7 @@
 						<second>-1.37496471700331924e+00</second>
 					</item>
 				</goal_state>
-				<score>7.86967415368791889e-01</score>
+				<score>4.92865475818263440e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -18609,34 +18609,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-8.80506681849162920e-01</second>
+						<second>5.00838522368900474e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.94011491471235320e-01</second>
+						<second>1.07374468738300410e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.02565167140924340e-01</second>
+						<second>2.82098636358451671e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.76477319031719060e+00</second>
+						<second>1.47814386917366503e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.22088887165023285e+00</second>
+						<second>2.51316575819986809e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.64599808909673384e+00</second>
+						<second>1.46487116051218869e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.62534859529353226e+00</second>
+						<second>1.62543113451124799e+00</second>
 					</item>
 				</goal_state>
-				<score>1.30900756946279162e+00</score>
+				<score>2.97652581329883696e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -18699,34 +18699,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-3.26975925070714379e-02</second>
+						<second>1.71221211415703345e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.12200247567090949e+00</second>
+						<second>-4.97545632046420480e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>6.13566706992761945e-01</second>
+						<second>1.46703350336024907e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.55200880544277497e+00</second>
+						<second>-2.46230628826992248e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.10525654690664643e+00</second>
+						<second>6.27816670391398435e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.07519763668234880e+00</second>
+						<second>-2.98273773055427593e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.79449588827544604e+00</second>
+						<second>1.79454173033185405e+00</second>
 					</item>
 				</goal_state>
-				<score>1.02536971506614227e+00</score>
+				<score>1.60373710495297528e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -18906,7 +18906,7 @@
 						<second>-7.55559935905880442e-01</second>
 					</item>
 				</goal_state>
-				<score>4.66252715399525564e-01</score>
+				<score>2.92538735875215658e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -18996,7 +18996,7 @@
 						<second>-1.18056840380282213e+00</second>
 					</item>
 				</goal_state>
-				<score>7.46025382331469644e-01</score>
+				<score>4.67530065122002195e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -19086,7 +19086,7 @@
 						<second>-1.49752420075291481e+00</second>
 					</item>
 				</goal_state>
-				<score>8.80196856586717979e-01</score>
+				<score>5.51517645357221600e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -19239,34 +19239,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.91940628658525037e+00</second>
+						<second>-3.76210063897258529e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96674194941214386e+00</second>
+						<second>5.28243035266753314e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.42817170581761199e+00</second>
+						<second>-2.79593452949352228e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.83517530433795795e+00</second>
+						<second>2.04351582117486341e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.88034355431886580e+00</second>
+						<second>-2.24754656919443213e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.10487283854936225e+00</second>
+						<second>-2.17743393104957583e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.88864534077426671e+00</second>
+						<second>-1.88876814823941808e+00</second>
 					</item>
 				</goal_state>
-				<score>5.26608283706936020e-01</score>
+				<score>3.36619258866834373e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -19419,34 +19419,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-7.18091401114453132e-01</second>
+						<second>-7.18034489008205545e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.32358615842659794e-01</second>
+						<second>2.33385293803693911e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.15225323275735245e-01</second>
+						<second>-1.15268227478424787e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.33401511733400874e-01</second>
+						<second>2.32732980764877362e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.92420294672036513e-02</second>
+						<second>-9.07173257185664023e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.83803840449989597e-01</second>
+						<second>-1.83460809214190279e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.39899720692192098e-01</second>
+						<second>-8.39905642625231819e-01</second>
 					</item>
 				</goal_state>
-				<score>6.42154842556137972e-01</score>
+				<score>4.03022271966780588e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -19536,7 +19536,7 @@
 						<second>-1.23898098377235000e+00</second>
 					</item>
 				</goal_state>
-				<score>8.54961841900390929e-01</score>
+				<score>5.35545650913152940e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -19626,7 +19626,7 @@
 						<second>-1.54869863850556344e+00</second>
 					</item>
 				</goal_state>
-				<score>8.25802757844167457e-01</score>
+				<score>5.17261324121935234e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -19689,37 +19689,37 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91008981549870804e+00</second>
+						<second>1.21461817045719811e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.11906462898043813e-02</second>
+						<second>-6.92204129187835138e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.29022314050032327e+00</second>
+						<second>7.76403907295011408e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.06042741301653654e-01</second>
+						<second>2.08459405453308388e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.74557603574861475e-01</second>
+						<second>-1.18154084308522145e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.96396093409975825e-01</second>
+						<second>1.91284438129934986e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.80295331768923406e+00</second>
+						<second>1.80326208424327317e+00</second>
 					</item>
 				</goal_state>
-				<score>5.48412408099122728e-01</score>
+				<score>9.82720090406584285e-02</score>
 			</item>
 			<item>
-				<reached>0</reached>
+				<reached>1</reached>
 				<goal>
 					<matrix>
 						<count>16</count>
@@ -19779,34 +19779,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.80037131547575813e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.51355926827428622e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-4.20459816661544639e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.49050793693009043e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-8.05934801008651780e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-9.06242246249186367e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.95478502350476102e+00</second>
 					</item>
 				</goal_state>
-				<score>0.00000000000000000e+00</score>
+				<score>4.09167051977267840e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -19986,7 +19986,7 @@
 						<second>-8.38054324324180144e-01</second>
 					</item>
 				</goal_state>
-				<score>6.40240909362604249e-01</score>
+				<score>4.01860301448655824e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -20076,7 +20076,7 @@
 						<second>-1.24409705782452895e+00</second>
 					</item>
 				</goal_state>
-				<score>8.56441736951577215e-01</score>
+				<score>5.36431946849181412e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -20166,7 +20166,7 @@
 						<second>-1.54369589496593007e+00</second>
 					</item>
 				</goal_state>
-				<score>8.27855265452758893e-01</score>
+				<score>5.18482590808771043e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -20229,34 +20229,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-5.04226650346596417e-01</second>
+						<second>1.90955757977990670e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.69029813872833712e+00</second>
+						<second>2.90376028456133528e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-3.76013792203408637e-01</second>
+						<second>1.22557433612242428e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.32509403910974144e+00</second>
+						<second>-2.83533290934838655e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-9.39270025665403296e-01</second>
+						<second>2.52073884505555956e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.59151188230410967e+00</second>
+						<second>-2.70480077821910703e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79948640577291719e+00</second>
+						<second>1.79942796019323414e+00</second>
 					</item>
 				</goal_state>
-				<score>7.20010521341616139e-01</score>
+				<score>1.51510876040393483e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -20319,34 +20319,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.13672789636050098e+00</second>
+						<second>4.50109771763929911e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-6.77564591904000868e-01</second>
+						<second>3.82367168496337673e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.02276528436802150e+00</second>
+						<second>-3.31639035001022375e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.15530268270667991e+00</second>
+						<second>9.58887594728148884e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.86244516319016862e+00</second>
+						<second>-7.42474032137473761e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.15239187742108684e+00</second>
+						<second>-1.09285708615231170e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.95359200540472422e+00</second>
+						<second>-1.95337874352773078e+00</second>
 					</item>
 				</goal_state>
-				<score>1.57050017887173676e+00</score>
+				<score>4.15294644428787565e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -20526,7 +20526,7 @@
 						<second>-7.45811391837392534e-01</second>
 					</item>
 				</goal_state>
-				<score>4.66317236636630161e-01</score>
+				<score>2.92676748746043165e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -20616,7 +20616,7 @@
 						<second>-1.18278805510680551e+00</second>
 					</item>
 				</goal_state>
-				<score>7.48770661878149113e-01</score>
+				<score>4.69229997012265698e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -20706,7 +20706,7 @@
 						<second>-1.48694600446771652e+00</second>
 					</item>
 				</goal_state>
-				<score>8.77710339492713598e-01</score>
+				<score>5.49969195594879473e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -20769,34 +20769,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.44874978693728482e-02</second>
+						<second>-1.56828725285248632e-02</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-8.23056269840525045e-01</second>
+						<second>2.31714934734214362e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-4.85296749900965330e-01</second>
+						<second>4.89036430502413466e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.14149999826592419e+00</second>
+						<second>4.01179612304743582e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.46679858713947908e-01</second>
+						<second>-2.28749256761436648e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.78418431258152532e+00</second>
+						<second>-3.96924325328158120e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75001536927578494e+00</second>
+						<second>-1.75003101712872988e+00</second>
 					</item>
 				</goal_state>
-				<score>1.03324961983299835e+00</score>
+				<score>6.00735060051756295e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -20859,34 +20859,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.43913354627744322e-01</second>
+						<second>-1.93364787672034161e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-8.38759444565720935e-01</second>
+						<second>-8.79041995641838381e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-4.57867141684112855e-01</second>
+						<second>5.86308699388130794e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.80199742905214988e+00</second>
+						<second>-7.55459078792816041e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.15620009994681983e-01</second>
+						<second>-2.10481067348694317e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14150000000000018e+00</second>
+						<second>-1.92029851829479714e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.89059260775855376e+00</second>
+						<second>1.89055865280903546e+00</second>
 					</item>
 				</goal_state>
-				<score>8.26991592064219017e-01</score>
+				<score>4.93933281928549198e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -21039,34 +21039,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.20778502594883164e+00</second>
+						<second>-1.04262370019100215e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.17216319124763535e+00</second>
+						<second>1.90006755916443844e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>2.27815822438868915e-01</second>
+						<second>-1.45030852046573067e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.67026693426815132e+00</second>
+						<second>2.02094703726312286e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.16156649375307430e-01</second>
+						<second>2.26638716289429976e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.77899986093149387e-01</second>
+						<second>6.45454941475661959e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-5.68937363132413165e-01</second>
+						<second>5.69325467944305164e-01</second>
 					</item>
 				</goal_state>
-				<score>5.83060435609753513e-01</score>
+				<score>4.16984737523974150e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -21129,34 +21129,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-8.22996704727125050e-01</second>
+						<second>-8.23276519848001320e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.30355285418106726e+00</second>
+						<second>-1.30503258147065337e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.96508387223242298e-02</second>
+						<second>-7.97011785097605369e-02</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.14790687197252117e+00</second>
+						<second>-1.14697205126235358e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.20256763718985082e-01</second>
+						<second>6.21898177220499004e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>9.73128290112511118e-01</second>
+						<second>9.71976076874577433e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.06034486684173679e+00</second>
+						<second>-1.05991089399637284e+00</second>
 					</item>
 				</goal_state>
-				<score>2.77367013846041954e-01</score>
+				<score>1.73225776580324363e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -21246,7 +21246,7 @@
 						<second>-1.38458695570385526e+00</second>
 					</item>
 				</goal_state>
-				<score>7.98748959530067082e-01</score>
+				<score>5.00338566646675309e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -21309,34 +21309,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.41843351581077148e+00</second>
+						<second>1.89474340822181730e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.78319563654310315e-01</second>
+						<second>-2.71011255872867052e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.34931182928850713e+00</second>
+						<second>-1.26133657917511943e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-9.96093992525061034e-01</second>
+						<second>2.88559121205305180e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-9.77776892531010633e-01</second>
+						<second>2.85156863700029550e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.20205536854555717e-01</second>
+						<second>-2.82865255852988007e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.62083700425522848e+00</second>
+						<second>1.62076556383674109e+00</second>
 					</item>
 				</goal_state>
-				<score>2.63531783019671462e+00</score>
+				<score>1.74458742276082490e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -21399,34 +21399,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.50543660616521846e+00</second>
+						<second>-1.20718394559884934e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>-4.25059937568204926e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.45213180240910900e+00</second>
+						<second>-1.36053917138443636e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.26396198950061311e+00</second>
+						<second>2.07388455580689302e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.79962259085595444e-01</second>
+						<second>1.96362718202290143e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.78345281350388640e-01</second>
+						<second>-5.84870262910485494e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.80311134697619613e+00</second>
+						<second>-1.80315012362311378e+00</second>
 					</item>
 				</goal_state>
-				<score>2.45698249081103093e+00</score>
+				<score>1.36387813479607101e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -21669,34 +21669,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.31279848142159627e+00</second>
+						<second>-1.31131843012686522e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.28427860333888932e+00</second>
+						<second>-1.27984438813988066e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>3.13529542881144319e-01</second>
+						<second>3.12234019862435541e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.93148330795419887e+00</second>
+						<second>-1.92848280964992025e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.26120040811812528e-01</second>
+						<second>-2.27356943045908505e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.00391452474418497e+00</second>
+						<second>1.00450241100577142e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.56747055780516575e-01</second>
+						<second>-8.56756688066897865e-01</second>
 					</item>
 				</goal_state>
-				<score>1.01960474299321935e+00</score>
+				<score>6.38875910816365522e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -21786,7 +21786,7 @@
 						<second>-1.20688686949219215e+00</second>
 					</item>
 				</goal_state>
-				<score>7.85048942750641521e-01</score>
+				<score>4.92361739727776720e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -21876,7 +21876,7 @@
 						<second>-1.42467214061561132e+00</second>
 					</item>
 				</goal_state>
-				<score>1.00877654328172284e+00</score>
+				<score>6.31928250606852981e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -22209,34 +22209,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36984688182599701e+00</second>
+						<second>-1.37424126273962410e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.09668359201378918e+00</second>
+						<second>2.01967625225471625e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>5.31403171902181337e-01</second>
+						<second>5.35708012416636126e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.22960457700863923e+00</second>
+						<second>8.91237428256520303e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-7.62503521049752275e-01</second>
+						<second>-7.58355312012824911e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>8.72145748988536140e-01</second>
+						<second>8.68574403314122612e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.73019876767437786e-01</second>
+						<second>4.72959132255644510e-01</second>
 					</item>
 				</goal_state>
-				<score>1.00019891493500324e+00</score>
+				<score>6.29711791089123674e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -22299,34 +22299,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-8.14415015216628957e-01</second>
+						<second>-1.38385264066857205e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.93294015592824575e+00</second>
+						<second>-1.05528029639533028e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-4.62587574265092172e-01</second>
+						<second>-4.17753102015192002e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.92539682101132770e-01</second>
+						<second>1.10101720874463282e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.46015193932073850e+00</second>
+						<second>2.66335921294723033e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.14420656594902059e+00</second>
+						<second>1.21007239440431702e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.36061044236672468e-01</second>
+						<second>9.36009014025575792e-01</second>
 					</item>
 				</goal_state>
-				<score>1.28056407120803861e+00</score>
+				<score>9.60178512657424155e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -22389,34 +22389,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-6.65303056321409958e-01</second>
+						<second>4.75828167714550554e-01</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.72084118564067690e+00</second>
+						<second>1.85889718909877510e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-4.55526390780067347e-01</second>
+						<second>7.42206329015679178e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.01857801980013307e+00</second>
+						<second>3.00275500148201768e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.26432473013494939e+00</second>
+						<second>-1.84224392650968327e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.36112555400504354e+00</second>
+						<second>-2.30389415522967544e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.22461195462655459e+00</second>
+						<second>-1.22465795415614487e+00</second>
 					</item>
 				</goal_state>
-				<score>1.13704095935319516e+00</score>
+				<score>1.13659343098244617e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -22839,34 +22839,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.39762143704029951e+00</second>
+						<second>-1.07427642504124354e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.12909883564437530e-01</second>
+						<second>6.68234645589212972e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.77314135531905159e-01</second>
+						<second>-5.85226190869771790e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.28170979356046999e+00</second>
+						<second>2.14709386016335868e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-9.87273257558904493e-01</second>
+						<second>1.82529233502628463e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.56940971734648160e+00</second>
+						<second>1.01868457718442107e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.90410927425032783e-01</second>
+						<second>4.90758181207536837e-01</second>
 					</item>
 				</goal_state>
-				<score>1.45529021425194038e+00</score>
+				<score>6.98397156825006499e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -25331,31 +25331,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.53153345297258481e+00</second>
+						<second>-1.75898434222349120e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.73943185941435696e-01</second>
+						<second>-9.02181748462884237e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64748772216048933e+00</second>
+						<second>1.67888200187009162e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.24390878253930492e+00</second>
+						<second>8.15671444567647730e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.06621847443260465e-01</second>
+						<second>6.09617182952577052e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.04786014836411012e+00</second>
+						<second>-9.87758593309020827e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.81651032287610903e-01</second>
+						<second>1.20884613498187687e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -25363,34 +25363,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.38907410341079363e+00</second>
+						<second>-1.48550636063145602e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.34751326569653374e-01</second>
+						<second>-8.57325974849173167e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.47511496728800617e+00</second>
+						<second>1.41344588603743015e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.14697583568047801e+00</second>
+						<second>7.28121702405696070e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.92445581713455982e-01</second>
+						<second>9.09873135668698318e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.07681608067439982e+00</second>
+						<second>-1.14830445015548910e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>5.09065740317828586e-01</second>
+						<second>5.09147957316665067e-01</second>
 					</item>
 				</goal_state>
-				<score>1.75624935457027176e+00</score>
+				<score>1.20531964250234588e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -25421,31 +25421,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91976185378250541e+00</second>
+						<second>-1.89648468844720419e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.30316440294132097e+00</second>
+						<second>-1.28240364971678300e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.46111322189258197e+00</second>
+						<second>1.63311863227613752e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.77135264777069157e-01</second>
+						<second>5.45450328001642615e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.99930916189362362e-01</second>
+						<second>4.28615433619086772e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.23167852576770809e+00</second>
+						<second>-1.25806031189375478e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.20867229288439715e+00</second>
+						<second>1.32194818522629132e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -25453,34 +25453,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66546977487627457e+00</second>
+						<second>-1.64876767855569395e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.30975980260474123e+00</second>
+						<second>-1.21577628295976714e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.45006209544128772e+00</second>
+						<second>1.48451934672912866e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.57511725738580866e-01</second>
+						<second>4.53653772799780142e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.09548167837764088e-01</second>
+						<second>7.20287473515345167e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.32301590495953492e+00</second>
+						<second>-1.28360544397899456e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.88192573850707734e-01</second>
+						<second>7.88660056112616914e-01</second>
 					</item>
 				</goal_state>
-				<score>2.57900683019595256e+00</score>
+				<score>1.73882388294874068e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -25511,31 +25511,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.89438833274384355e+00</second>
+						<second>-1.87711172410108773e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.03565771589190492e+00</second>
+						<second>-1.34771669724438903e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.20601329656198031e+00</second>
+						<second>1.72639892434726727e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.19261550976849828e-01</second>
+						<second>5.90302281765893611e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.54856362719684393e-01</second>
+						<second>3.11059033956159858e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.29875650696825962e-01</second>
+						<second>-1.31319949045065765e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.42764828919268272e-01</second>
+						<second>1.46478692545186950e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -25543,34 +25543,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70180119824979714e+00</second>
+						<second>-1.64646806859902961e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.61208933347308236e+00</second>
+						<second>-1.27758389249956350e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.46789399067866877e+00</second>
+						<second>1.60528396544526619e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.78573417810699631e-01</second>
+						<second>5.18815544643985382e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.38729469789955151e-01</second>
+						<second>6.56061395328968788e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.55641411698714749e+00</second>
+						<second>-1.40359833624412622e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.58804363550193961e-01</second>
+						<second>8.58963852465529976e-01</second>
 					</item>
 				</goal_state>
-				<score>2.86537122691224111e+00</score>
+				<score>1.84585258982427752e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -25601,31 +25601,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.89438833274384355e+00</second>
+						<second>1.86074417243399370e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.03565771589190492e+00</second>
+						<second>-2.95443849774183054e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.20601329656198031e+00</second>
+						<second>1.50914318318281682e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.19261550976849828e-01</second>
+						<second>2.46769284379589626e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.54856362719684393e-01</second>
+						<second>7.97024855384040332e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.29875650696825962e-01</second>
+						<second>-2.81871344513693378e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.42764828919268272e-01</second>
+						<second>6.88964561397583219e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -25633,34 +25633,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73460503512780018e+00</second>
+						<second>1.65443704190296415e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.28448050793543178e+00</second>
+						<second>-2.84413641442405263e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.47679066904701273e+00</second>
+						<second>1.39338416780093910e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.90867035649140537e-01</second>
+						<second>2.39612632811555493e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.74561620978228560e-01</second>
+						<second>9.02717006635015307e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.52996780009756805e-01</second>
+						<second>-2.64805206937385318e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.00617945325530367e-01</second>
+						<second>6.01588854346977953e-01</second>
 					</item>
 				</goal_state>
-				<score>2.05977624675478443e+00</score>
+				<score>1.45044394347068395e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -25691,31 +25691,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85490735972754139e+00</second>
+						<second>-1.67760451438264013e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.85755453350982225e+00</second>
+						<second>-8.63980278887908071e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.66141532481036602e+00</second>
+						<second>1.55818641248161938e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50891182085985509e+00</second>
+						<second>8.64459164680135506e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.59843576502383611e+00</second>
+						<second>7.93663232076335934e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.14577890144303929e+00</second>
+						<second>-1.13084153831213952e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.06251881508530110e+00</second>
+						<second>7.81744224975808089e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -25723,34 +25723,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.83360884213563291e+00</second>
+						<second>-1.82071524295609821e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.92958175926217423e+00</second>
+						<second>-1.17133520791414081e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.56922605030601625e+00</second>
+						<second>1.58671260971700745e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.54053993085076923e+00</second>
+						<second>6.44679715106950324e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.50630410683652505e+00</second>
+						<second>6.42023042292822810e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.17175106818797792e+00</second>
+						<second>9.88962308619349528e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.42909495308566714e-01</second>
+						<second>9.43350516746099044e-01</second>
 					</item>
 				</goal_state>
-				<score>2.73833264850141678e+00</score>
+				<score>1.94158431618014826e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -25781,31 +25781,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61769388841950512e+00</second>
+						<second>-1.75898434222349120e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.38848308169308821e+00</second>
+						<second>-9.02181748462884237e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91602565380586687e+00</second>
+						<second>1.67888200187009162e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.09383642848697082e+00</second>
+						<second>8.15671444567647730e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.53563760309345865e+00</second>
+						<second>6.09617182952577052e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.15840472683926254e+00</second>
+						<second>-9.87758593309020827e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32188649050487128e+00</second>
+						<second>1.20884613498187687e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -25813,34 +25813,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.88566865222674851e+00</second>
+						<second>-1.91440524810929880e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.37577388121325095e+00</second>
+						<second>-1.47747178328262341e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.61480352082282730e+00</second>
+						<second>1.56164017028430036e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.32038987290790799e-01</second>
+						<second>4.16483380778542578e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.31608048721753712e-01</second>
+						<second>5.24068771668120492e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>9.48037229724794317e-01</second>
+						<second>8.88678402970259906e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.06263268088547380e+00</second>
+						<second>1.06234502583793722e+00</second>
 					</item>
 				</goal_state>
-				<score>2.97853579320359563e+00</score>
+				<score>2.04297275768612535e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -25871,31 +25871,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70916885857598388e+00</second>
+						<second>-1.85585545833598120e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.80872433337070659e+00</second>
+						<second>-1.38566797755045656e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.38775863373580544e+00</second>
+						<second>1.76524508493471166e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.30205970064226544e-02</second>
+						<second>5.53675521165260975e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.50159876650583168e-01</second>
+						<second>1.36012956857808037e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.65171257776160441e+00</second>
+						<second>-1.29171456448491484e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.58698288929702569e-01</second>
+						<second>1.70864166684574248e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -25903,34 +25903,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979999999999995e+00</second>
+						<second>-1.91815918850404499e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.40538538113626199e+00</second>
+						<second>-2.41398288657026061e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.32628472886373538e+00</second>
+						<second>1.32372451360827403e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.75872425370206986e-01</second>
+						<second>-3.84897888836304380e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.32702448192824285e-01</second>
+						<second>6.35843678080842523e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.38228833737893286e-01</second>
+						<second>4.33657712086622904e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.02767833755982729e+00</second>
+						<second>1.02743738492647996e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88357235575551707e+00</score>
+				<score>2.02691312715322647e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -25961,31 +25961,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.88858173533046636e+00</second>
+						<second>1.81020245600818908e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.85011296713659235e+00</second>
+						<second>-2.81085527379622624e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62141289014037171e+00</second>
+						<second>1.03982716656695895e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.05165358780430518e+00</second>
+						<second>2.35077625777318611e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31608853617363986e+00</second>
+						<second>6.91760459549879525e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.46275893871038697e-02</second>
+						<second>-3.02291412831996498e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-7.94857136755156790e-01</second>
+						<second>1.48878768065720890e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -25993,34 +25993,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73845365113803330e+00</second>
+						<second>1.86092708982112476e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.90633937476718662e+00</second>
+						<second>-2.95367724569936252e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.51213740750317660e+00</second>
+						<second>1.50918883905287404e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.03803551979915598e+00</second>
+						<second>2.46851868301573729e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.20958329212663074e+00</second>
+						<second>7.96777056470419520e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20861037790856335e-01</second>
+						<second>-2.81848017355377545e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-6.89434430445925783e-01</second>
+						<second>6.88977919481381873e-01</second>
 					</item>
 				</goal_state>
-				<score>2.34282407268101167e+00</score>
+				<score>1.59362716306390428e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26051,31 +26051,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77056668024924546e+00</second>
+						<second>-1.90664712158350813e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.07088825417249245e+00</second>
+						<second>-1.32914218320266775e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.88372806912077628e+00</second>
+						<second>1.62527095779734565e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.58492626658123026e+00</second>
+						<second>3.04039462352498346e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-3.06746848505459102e+00</second>
+						<second>-2.77467252524193804e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.21224315502393232e+00</second>
+						<second>-1.23420333828543027e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95033305200882157e+00</second>
+						<second>1.95032560574722491e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26083,34 +26083,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.76577378666234819e+00</second>
+						<second>-1.91978252683742800e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.99664117009518804e+00</second>
+						<second>-1.44028423254754889e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.86796749162818920e+00</second>
+						<second>1.65639506953282445e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.34730382106805679e+00</second>
+						<second>4.85737992964276111e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.78163388304197534e+00</second>
+						<second>2.98587233686228193e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.96675406574584533e+00</second>
+						<second>-1.38851267242427379e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.46463993745789089e+00</second>
+						<second>1.46458532290340715e+00</second>
 					</item>
 				</goal_state>
-				<score>3.15283201945132197e+00</score>
+				<score>2.02992966183689560e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26141,31 +26141,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67036370632477005e+00</second>
+						<second>1.86074417243399370e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.82911906499151034e+00</second>
+						<second>-2.95443849774183054e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>7.77050033334609092e-01</second>
+						<second>1.50914318318281682e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.96846753830387078e-01</second>
+						<second>2.46769284379589626e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.40337133149682125e-01</second>
+						<second>7.97024855384040332e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.68117414603628257e+00</second>
+						<second>-2.81871344513693378e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.92781996704816128e+00</second>
+						<second>6.88964561397583219e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26173,34 +26173,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73643636432677173e+00</second>
+						<second>1.81020245600818908e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96700000000000008e+00</second>
+						<second>-2.81085527379622624e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.01878274703353910e+00</second>
+						<second>1.03982716656695895e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.97534025482065623e-01</second>
+						<second>2.35077625777318611e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.87750756914439298e-01</second>
+						<second>6.91760459549879525e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.12586922386320393e-02</second>
+						<second>-3.02291412831996498e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.48868350544926020e+00</second>
+						<second>1.48878768065720890e+00</second>
 					</item>
 				</goal_state>
-				<score>3.13200839639488127e+00</score>
+				<score>1.99164555893274225e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26231,31 +26231,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.83693070389912227e+00</second>
+						<second>-1.89224372143655883e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.82927561456175836e+00</second>
+						<second>2.92419348544080515e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.46863845655415437e+00</second>
+						<second>1.45379735976819657e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.13583353493909334e+00</second>
+						<second>-9.12021362349807130e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31602270875400817e+00</second>
+						<second>7.69580921312952748e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.50312110900653939e-01</second>
+						<second>-1.09586556999951928e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.26240530216323976e+00</second>
+						<second>1.26211855936764339e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26263,34 +26263,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.77730466495425832e+00</second>
+						<second>-1.77753845939385502e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96693061005466019e+00</second>
+						<second>2.96699961481169083e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.35301256598507447e+00</second>
+						<second>1.35308938358546738e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.02883438955599127e+00</second>
+						<second>-1.11230730774814623e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.23154570961572851e+00</second>
+						<second>9.09923396634078174e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-6.56557792585911321e-02</second>
+						<second>-6.57703657120262408e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.11737135502758700e+00</second>
+						<second>1.11743511001640572e+00</second>
 					</item>
 				</goal_state>
-				<score>2.95305310401394205e+00</score>
+				<score>2.07176141101794026e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26321,31 +26321,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.77755263558543453e+00</second>
+						<second>1.90677101350841594e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96699989279006138e+00</second>
+						<second>-2.96700000000000008e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.35310061129518022e+00</second>
+						<second>1.16132762993560745e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.02930959564206281e+00</second>
+						<second>2.52869414024791794e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.23167488840808570e+00</second>
+						<second>5.84693894201731346e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-6.57716466066921579e-02</second>
+						<second>-3.05324261388614815e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.11743113545222017e+00</second>
+						<second>1.64523893003201716e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26353,34 +26353,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.88858173533046636e+00</second>
+						<second>1.85864673701707672e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.85011296713659235e+00</second>
+						<second>2.77703289326050662e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62141289014037171e+00</second>
+						<second>1.63077041234934050e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.05165358780430518e+00</second>
+						<second>1.97443941924253319e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31608853617363986e+00</second>
+						<second>8.52472478782023257e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.46275893871038697e-02</second>
+						<second>3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-7.94857136755156790e-01</second>
+						<second>7.94346403987332250e-01</second>
 					</item>
 				</goal_state>
-				<score>2.66341740938212457e+00</score>
+				<score>1.69181075355042954e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26411,31 +26411,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68382121771877924e+00</second>
+						<second>-1.67112941089740730e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.79366981286883442e+00</second>
+						<second>-2.96699985747430972e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.49970152778759314e-01</second>
+						<second>-7.24593750689819016e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.97783892398964523e-01</second>
+						<second>2.53984108501410821e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.47260446361471509e-01</second>
+						<second>-2.66041708376390806e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.53276303456733309e+00</second>
+						<second>-2.87263375843483448e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70861024677965845e+00</second>
+						<second>-2.10510161639243609e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26443,34 +26443,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76432032113259485e+00</second>
+						<second>-1.73895754432357230e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.87785049076220245e+00</second>
+						<second>-2.93636036680951840e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.23704501601275485e-01</second>
+						<second>-9.15560862248377738e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.54266727284059657e-01</second>
+						<second>2.45625143964245307e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.69774067705066001e-01</second>
+						<second>-2.52905732986149889e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.73707676792904664e+00</second>
+						<second>-2.76941943115295475e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.83969489732625302e+00</second>
+						<second>-1.83963524045101101e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55087012000224123e+00</score>
+				<score>1.60754134210038951e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26501,31 +26501,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68382121771877924e+00</second>
+						<second>-1.77230653496244694e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.79366981286883442e+00</second>
+						<second>-7.33376172770565521e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.49970152778759314e-01</second>
+						<second>-8.73595581161907497e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.97783892398964523e-01</second>
+						<second>-5.18625279468276856e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.47260446361471509e-01</second>
+						<second>-2.62974880159214974e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.53276303456733309e+00</second>
+						<second>3.14149996087379124e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70861024677965845e+00</second>
+						<second>2.13510519039842128e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26533,34 +26533,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.90671443966079757e+00</second>
+						<second>1.84016620003968745e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96700000000000008e+00</second>
+						<second>3.33659334539958344e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.16128734813458734e+00</second>
+						<second>-1.15172648805202638e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.12770414495120375e-01</second>
+						<second>2.41806161390585039e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.84660858584042598e-01</second>
+						<second>-2.45691762540465142e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>8.82601379903193706e-02</second>
+						<second>3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.64534015551516544e+00</second>
+						<second>1.64533671203304799e+00</second>
 					</item>
 				</goal_state>
-				<score>2.89507518002620889e+00</score>
+				<score>1.90415311914916174e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26591,31 +26591,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91969890351458461e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96320782660357018e+00</second>
+						<second>2.82858734000319467e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37175494457080327e+00</second>
+						<second>1.37605679147935378e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.39425974887273663e+00</second>
+						<second>-6.94600447857233849e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.50759068322008760e+00</second>
+						<second>5.74521611584035918e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13136781864708441e-01</second>
+						<second>-3.50592085066757042e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.55297671528658121e+00</second>
+						<second>1.70691552402756441e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26623,34 +26623,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91559279722673237e+00</second>
+						<second>-1.91551441644699616e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>2.96689857854297800e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44877935491392051e+00</second>
+						<second>1.44877177528707657e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27267919981740985e+00</second>
+						<second>-8.69084508104562836e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.39744767907745171e+00</second>
+						<second>7.44228925115176909e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.95854675647376614e-02</second>
+						<second>-8.96330665942104560e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.26209292166627085e+00</second>
+						<second>1.26209551269828579e+00</second>
 					</item>
 				</goal_state>
-				<score>3.24930532361811997e+00</score>
+				<score>2.08356641678454024e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26681,31 +26681,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979945136074881e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.82756000014498987e+00</second>
+						<second>2.82858734000319467e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37660821856964355e+00</second>
+						<second>1.37605679147935378e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44626593976193751e+00</second>
+						<second>-6.94600447857233849e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.56648163821221598e+00</second>
+						<second>5.74521611584035918e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.51462962043233518e-01</second>
+						<second>-3.50592085066757042e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.70657169966797695e+00</second>
+						<second>1.70691552402756441e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26713,34 +26713,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.64571191192112232e+00</second>
+						<second>-1.64571275751411772e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96699999993822594e+00</second>
+						<second>2.96699999991979446e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.84622695735727160e-01</second>
+						<second>8.84623237656669947e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.42861785976288269e+00</second>
+						<second>-7.12975412666878250e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.39151429858587949e+00</second>
+						<second>7.50078461456728185e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.10782441521467589e+00</second>
+						<second>-3.10782452005099996e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.02190006863153560e+00</second>
+						<second>2.02189959608730119e+00</second>
 					</item>
 				</goal_state>
-				<score>2.11139341966240446e+00</score>
+				<score>1.32410498093219281e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26771,31 +26771,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91969890351458461e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96320782660357018e+00</second>
+						<second>2.82858734000319467e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37175494457080327e+00</second>
+						<second>1.37605679147935378e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.39425974887273663e+00</second>
+						<second>-6.94600447857233849e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.50759068322008760e+00</second>
+						<second>5.74521611584035918e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13136781864708441e-01</second>
+						<second>-3.50592085066757042e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.55297671528658121e+00</second>
+						<second>1.70691552402756441e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26803,34 +26803,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78985632045988452e+00</second>
+						<second>-1.76450330218373685e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96699999109129164e+00</second>
+						<second>2.92121992792664109e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.09594750456878920e+00</second>
+						<second>1.10232365785115660e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.42565080387072296e+00</second>
+						<second>-7.44215455882631161e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.44198019251436227e+00</second>
+						<second>7.35450412394251685e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.89037672528895112e-01</second>
+						<second>-2.17886942250461929e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87555194285101900e+00</second>
+						<second>1.87549377598813360e+00</second>
 					</item>
 				</goal_state>
-				<score>2.49956404149079070e+00</score>
+				<score>1.58875692441900779e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26861,31 +26861,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.82858734000319467e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.37605679147935378e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-6.94600447857233849e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>5.74521611584035918e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-3.50592085066757042e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.70691552402756441e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26893,34 +26893,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91969890351458461e+00</second>
+						<second>-1.89441534424694158e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96320782660357018e+00</second>
+						<second>2.92011434906519973e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37175494457080327e+00</second>
+						<second>1.37791306822965454e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.39425974887273663e+00</second>
+						<second>-7.88051804905474995e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.50759068322008760e+00</second>
+						<second>6.65133949618377018e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13136781864708441e-01</second>
+						<second>-2.41016875117575496e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.55297671528658121e+00</second>
+						<second>1.55314467704682913e+00</second>
 					</item>
 				</goal_state>
-				<score>3.08622522320939607e+00</score>
+				<score>1.97699868907353055e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -26951,31 +26951,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73767005583987189e+00</second>
+						<second>-1.86772822812696182e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.82794106276114654e-01</second>
+						<second>2.87681627637262149e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.29010797147696743e-01</second>
+						<second>1.38549159699800817e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-4.96844218509007174e-01</second>
+						<second>-8.28431975884378335e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.18736103867719933e-01</second>
+						<second>6.96355125478039239e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.71231272818485303e-01</second>
+						<second>-2.67795666688493472e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.19633811398091305e+00</second>
+						<second>1.55319852710120698e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -26983,34 +26983,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.67163682240829337e+00</second>
+						<second>-1.77230653496244694e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.20775336534649014e-01</second>
+						<second>-7.33376172770565521e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.04870068879646494e-01</second>
+						<second>-8.73595581161907497e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.14186447570347460e-01</second>
+						<second>-5.18625279468276856e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.13941311284461699e-01</second>
+						<second>-2.62974880159214974e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.59286796880928005e-01</second>
+						<second>3.14149996087379124e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.13516254928943283e+00</second>
+						<second>2.13510519039842128e+00</second>
 					</item>
 				</goal_state>
-				<score>1.80122071559398589e+00</score>
+				<score>1.13851228746772865e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27041,31 +27041,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81046877911026249e+00</second>
+						<second>-1.81862692041195051e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.66904686269479896e-01</second>
+						<second>-1.47327249453790360e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.61925678195790335e-01</second>
+						<second>-8.86973069373741096e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.55227369477201627e-01</second>
+						<second>-3.98272275704297629e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.08913892870775819e-01</second>
+						<second>-2.71869059061943164e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.83019048046749466e-01</second>
+						<second>3.04224795465348175e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23355078064531121e+00</second>
+						<second>2.19641956548873285e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27073,34 +27073,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.82351156045076945e+00</second>
+						<second>-1.91979965386024110e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.13157575006690225e-01</second>
+						<second>-1.06895543373810686e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.10013043441297564e+00</second>
+						<second>-1.06781527450415470e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.27130085717839902e-01</second>
+						<second>-4.94733877732282834e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.32418792253928608e-01</second>
+						<second>-2.68038450108842774e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.47226508039611881e-01</second>
+						<second>3.05449963460954077e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.02113601224369965e+00</second>
+						<second>2.02111158562203252e+00</second>
 					</item>
 				</goal_state>
-				<score>2.11572347952623829e+00</score>
+				<score>1.35220051171668215e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27131,31 +27131,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91969890351458461e+00</second>
+						<second>-1.74623635860835602e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96320782660357018e+00</second>
+						<second>2.88914619283379981e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37175494457080327e+00</second>
+						<second>1.10774804002428429e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.39425974887273663e+00</second>
+						<second>-7.63568524123825698e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.50759068322008760e+00</second>
+						<second>7.60432737485013388e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13136781864708441e-01</second>
+						<second>-2.37670783726409152e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.55297671528658121e+00</second>
+						<second>1.87543217598811829e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27163,34 +27163,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979945136074881e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.82756000014498987e+00</second>
+						<second>2.82858734000319467e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37660821856964355e+00</second>
+						<second>1.37605679147935378e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44626593976193751e+00</second>
+						<second>-6.94600447857233849e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.56648163821221598e+00</second>
+						<second>5.74521611584035918e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.51462962043233518e-01</second>
+						<second>-3.50592085066757042e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.70657169966797695e+00</second>
+						<second>1.70691552402756441e+00</second>
 					</item>
 				</goal_state>
-				<score>2.85393480187066562e+00</score>
+				<score>1.81665525348519180e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27221,31 +27221,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.28412089218715608e+00</second>
+						<second>-1.91963427224258631e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.20243170065254024e+00</second>
+						<second>-1.06321828278368571e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.20538832501352755e+00</second>
+						<second>-1.06761424121323212e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.33912915583231618e+00</second>
+						<second>-4.94849851006691543e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-1.96393597548850907e+00</second>
+						<second>-2.68064966242545166e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.53920838898038648e+00</second>
+						<second>3.05462308593289755e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.13504078639388295e+00</second>
+						<second>2.02115691010592924e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27253,34 +27253,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.55879675094240899e+00</second>
+						<second>-1.91973107015799105e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.21962202359560168e+00</second>
+						<second>-3.84174933426533194e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44032572623567345e+00</second>
+						<second>-1.11958063456495127e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.35026838188262488e+00</second>
+						<second>-4.45855037735516213e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.24740522729476444e+00</second>
+						<second>-2.67667205588571555e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.26783084394147716e+00</second>
+						<second>2.76802049525265970e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.09715294734037361e+00</second>
+						<second>2.09703766496971200e+00</second>
 					</item>
 				</goal_state>
-				<score>1.82794735082438553e+00</score>
+				<score>1.21412832343530272e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27311,31 +27311,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979945136074881e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.82756000014498987e+00</second>
+						<second>2.82858734000319467e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37660821856964355e+00</second>
+						<second>1.37605679147935378e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44626593976193751e+00</second>
+						<second>-6.94600447857233849e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.56648163821221598e+00</second>
+						<second>5.74521611584035918e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.51462962043233518e-01</second>
+						<second>-3.50592085066757042e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.70657169966797695e+00</second>
+						<second>1.70691552402756441e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27343,34 +27343,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91976366967758727e+00</second>
+						<second>-1.91976265824414383e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.60944675272011439e+00</second>
+						<second>2.60944277035716743e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.47016038483363554e+00</second>
+						<second>1.47016290684761985e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40928528208225590e+00</second>
+						<second>-7.32310747161661113e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.59495987891154334e+00</second>
+						<second>5.46635119284879289e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.49378241225392028e-01</second>
+						<second>-5.49383999572054971e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75229127949802055e+00</second>
+						<second>1.75229033944555268e+00</second>
 					</item>
 				</goal_state>
-				<score>2.70078461231943301e+00</score>
+				<score>1.73173267957418553e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27401,31 +27401,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.55879675094240899e+00</second>
+						<second>-1.91963427224258631e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.21962202359560168e+00</second>
+						<second>-1.06321828278368571e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44032572623567345e+00</second>
+						<second>-1.06761424121323212e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.35026838188262488e+00</second>
+						<second>-4.94849851006691543e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.24740522729476444e+00</second>
+						<second>-2.68064966242545166e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.26783084394147716e+00</second>
+						<second>3.05462308593289755e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.09715294734037361e+00</second>
+						<second>2.02115691010592924e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27433,34 +27433,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70973868526433348e+00</second>
+						<second>-1.91914914581025853e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.13465494141019230e+00</second>
+						<second>-7.13641330677951768e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.52541428617519270e+00</second>
+						<second>-1.27483420800000347e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.45360459800229069e+00</second>
+						<second>-4.46378315883716570e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.45343966798897828e+00</second>
+						<second>-2.67117768658936727e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.07375289197738866e+00</second>
+						<second>2.40781387891054477e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.09834208018544732e+00</second>
+						<second>2.09816845980845024e+00</second>
 					</item>
 				</goal_state>
-				<score>1.83991615996556024e+00</score>
+				<score>1.20280188297359050e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27491,31 +27491,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81046877911026249e+00</second>
+						<second>-1.91976265824414383e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.66904686269479896e-01</second>
+						<second>2.60944277035716743e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.61925678195790335e-01</second>
+						<second>1.47016290684761985e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.55227369477201627e-01</second>
+						<second>-7.32310747161661113e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.08913892870775819e-01</second>
+						<second>5.46635119284879289e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.83019048046749466e-01</second>
+						<second>-5.49383999572054971e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23355078064531121e+00</second>
+						<second>1.75229033944555268e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27523,34 +27523,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.91979999999999995e+00</second>
+						<second>-1.91979779512136006e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.35506134573384474e-01</second>
+						<second>2.45267304161667976e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.47321701443612763e+00</second>
+						<second>1.55710118600715175e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.33548484254081479e-01</second>
+						<second>-7.33596735580075543e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-5.45261440489975158e-01</second>
+						<second>4.54856297058935599e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.58899827189118925e+00</second>
+						<second>-7.24728304728067263e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75067389718719335e+00</second>
+						<second>1.75067128291096075e+00</second>
 					</item>
 				</goal_state>
-				<score>2.68134014893157513e+00</score>
+				<score>1.71225238732195029e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27581,31 +27581,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.21300886886236725e+00</second>
+						<second>-1.84392594343794758e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>9.25358368089294947e-01</second>
+						<second>-1.06870613741542608e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.42533148022140788e+00</second>
+						<second>-1.35036356874902941e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.12794353525002133e+00</second>
+						<second>-3.62701774961848633e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.89877375670479909e+00</second>
+						<second>-2.62061393140722965e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.14254866666904209e-01</second>
+						<second>2.06391667680832613e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.87149589629349333e+00</second>
+						<second>2.19434682050611451e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27613,34 +27613,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78435873864266470e+00</second>
+						<second>-1.90249239864117814e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.20447824058362740e-02</second>
+						<second>-1.11293954879734769e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.74359929360458032e-01</second>
+						<second>-1.37475120593888689e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>4.97106204185592815e-01</second>
+						<second>-3.05434296684739592e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.65602674417055029e+00</second>
+						<second>-2.74281899469910861e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14110255101022950e+00</second>
+						<second>2.00499300264824054e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14343501476974785e+00</second>
+						<second>2.14347953715500594e+00</second>
 					</item>
 				</goal_state>
-				<score>1.79709988676116561e+00</score>
+				<score>1.11534526858620281e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27671,31 +27671,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81878511637749329e+00</second>
+						<second>-1.91924145435578142e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.23695875169699032e-01</second>
+						<second>-1.07032693211532148e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.46439707977363764e-01</second>
+						<second>-1.33012944827997015e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.42563015188256659e-01</second>
+						<second>-2.63435744078442946e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-4.80643119460821555e-01</second>
+						<second>-2.76672600074024633e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.45171057621394994e-01</second>
+						<second>2.06481531551584707e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23337729625187453e+00</second>
+						<second>2.14338056073646932e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27703,34 +27703,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.83906436319784583e+00</second>
+						<second>-1.91979894210484048e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.72982808796894572e-01</second>
+						<second>-9.76452621080059702e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.09009218730911694e+00</second>
+						<second>-1.47267154492116870e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.06907580079819153e-01</second>
+						<second>-4.92225315923981055e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.05064238863279424e-01</second>
+						<second>-2.75560827590958723e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.13657257703061959e-01</second>
+						<second>2.08454417522218272e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.01890526354003752e+00</second>
+						<second>2.01888186416396609e+00</second>
 					</item>
 				</goal_state>
-				<score>2.12032625353634829e+00</score>
+				<score>1.33130195702942045e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27761,31 +27761,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85912022245366959e+00</second>
+						<second>-1.91979779512136006e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.08283851344100450e-02</second>
+						<second>2.45267304161667976e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.79410515019637296e-01</second>
+						<second>1.55710118600715175e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.35530877370318004e-01</second>
+						<second>-7.33596735580075543e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.84419919361993445e+00</second>
+						<second>4.54856297058935599e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.12394418269568197e+00</second>
+						<second>-7.24728304728067263e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19437947792203270e+00</second>
+						<second>1.75067128291096075e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27793,34 +27793,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59040032317572422e+00</second>
+						<second>-1.91979887073210786e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>7.25748139098524758e-01</second>
+						<second>2.28384393552988874e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.55252373234415697e+00</second>
+						<second>1.64448016221448978e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.05859574777155374e+00</second>
+						<second>-6.90767869750637864e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.24939292366541110e+00</second>
+						<second>3.23839241101177511e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.22358924053912133e-01</second>
+						<second>-8.39904718692343955e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70879017276738199e+00</second>
+						<second>1.70884812033759625e+00</second>
 					</item>
 				</goal_state>
-				<score>2.73475493310752960e+00</score>
+				<score>1.74689471462103674e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27851,31 +27851,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.63523041863856133e+00</second>
+						<second>-1.91924145435578142e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.24752987467881832e-01</second>
+						<second>-1.07032693211532148e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.69679628135545912e-01</second>
+						<second>-1.33012944827997015e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.32305331533912973e-01</second>
+						<second>-2.63435744078442946e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.53168909464417080e+00</second>
+						<second>-2.76672600074024633e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71944525577046559e+00</second>
+						<second>2.06481531551584707e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91977934788938476e+00</second>
+						<second>2.14338056073646932e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27883,34 +27883,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78203500138374138e+00</second>
+						<second>-1.91959855975022764e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.27978460146796980e-01</second>
+						<second>-1.28718996055976764e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.88101320552870166e-01</second>
+						<second>-1.53801849211403230e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.92690938843703385e-01</second>
+						<second>-3.77384210194172010e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.62333651587539540e+00</second>
+						<second>-2.90169555944808888e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.93162405027364104e+00</second>
+						<second>1.76533960843441839e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.01047153560230329e+00</second>
+						<second>2.01025235394594670e+00</second>
 					</item>
 				</goal_state>
-				<score>2.14369794781655632e+00</score>
+				<score>1.34751411661454518e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -27941,31 +27941,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85805360557982602e+00</second>
+						<second>1.90688714724360420e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.75689468355472123e+00</second>
+						<second>2.62568492148069155e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64063811762531331e+00</second>
+						<second>-1.62594994676778737e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.94618515104317380e+00</second>
+						<second>-2.07520682797054024e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.57506152855927795e-01</second>
+						<second>2.32802056144503711e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14149939473886430e+00</second>
+						<second>3.11740535949788722e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.72739521482828651e-01</second>
+						<second>7.72613168753316870e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -27973,34 +27973,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61361950955022571e+00</second>
+						<second>1.85440564064621616e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.67969749140427815e+00</second>
+						<second>5.08365499559876588e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.16529629000683621e+00</second>
+						<second>1.08932988089394178e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.25588823197027821e+00</second>
+						<second>6.37754121882949887e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-9.21535386856614958e-01</second>
+						<second>-6.03347158522170579e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.78085331633099564e+00</second>
+						<second>-3.03471650105087631e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.87147638534520722e+00</second>
+						<second>-1.87144701088035803e+00</second>
 					</item>
 				</goal_state>
-				<score>2.46953421708869625e+00</score>
+				<score>1.59925525647737349e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28031,31 +28031,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85805360557982602e+00</second>
+						<second>1.90688714724360420e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.75689468355472123e+00</second>
+						<second>2.62568492148069155e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64063811762531331e+00</second>
+						<second>-1.62594994676778737e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.94618515104317380e+00</second>
+						<second>-2.07520682797054024e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.57506152855927795e-01</second>
+						<second>2.32802056144503711e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14149939473886430e+00</second>
+						<second>3.11740535949788722e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.72739521482828651e-01</second>
+						<second>7.72613168753316870e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28063,34 +28063,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72484293883013562e+00</second>
+						<second>1.91929444038230956e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.67563801967791148e+00</second>
+						<second>1.74170365353391088e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.43607506677960295e+00</second>
+						<second>-1.36814132753961482e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.13392111505164994e+00</second>
+						<second>-2.39694968755328963e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.41673556929095401e-01</second>
+						<second>2.50781863309288777e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.76558597281324836e+00</second>
+						<second>-2.93193987890819763e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.55605715978746817e+00</second>
+						<second>1.55574684140787589e+00</second>
 					</item>
 				</goal_state>
-				<score>3.04469197753052256e+00</score>
+				<score>1.97821505191479174e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28121,31 +28121,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.63523041863856133e+00</second>
+						<second>-1.91959855975022764e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.24752987467881832e-01</second>
+						<second>-1.28718996055976764e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.69679628135545912e-01</second>
+						<second>-1.53801849211403230e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.32305331533912973e-01</second>
+						<second>-3.77384210194172010e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.53168909464417080e+00</second>
+						<second>-2.90169555944808888e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71944525577046559e+00</second>
+						<second>1.76533960843441839e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91977934788938476e+00</second>
+						<second>2.01025235394594670e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28153,34 +28153,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73254856244761690e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.90109703440959010e-01</second>
+						<second>-1.38760210493103275e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.12676329589922397e-01</second>
+						<second>-1.59666258587359522e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.92545466147565403e-01</second>
+						<second>-3.87272960346193740e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51905021486234304e+00</second>
+						<second>-3.09013511379292494e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.77883103260827058e+00</second>
+						<second>1.65782922603420246e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.84180491085427445e+00</second>
+						<second>1.84170789159214432e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55327658368746935e+00</score>
+				<score>1.61728453660857752e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28211,31 +28211,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.81748038472686546e+00</second>
+						<second>1.90027721862750276e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.05483179002218712e-02</second>
+						<second>-9.41233110306930881e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.52649683277555126e+00</second>
+						<second>1.33619557762236463e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.95974397519865740e-01</second>
+						<second>8.62490195606291254e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.27705592182947392e+00</second>
+						<second>-7.73491906301295495e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.71899846432171077e-01</second>
+						<second>3.11972931924754437e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.41654345881488952e-01</second>
+						<second>-1.13897893672029671e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28243,34 +28243,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.84758358655102706e+00</second>
+						<second>1.83143037212214255e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.94028948339715285e-02</second>
+						<second>-2.67627862588031423e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.14239666116054228e+00</second>
+						<second>1.14151657064492551e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.02315007493416132e-01</second>
+						<second>7.26609165301088100e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.47515566697445655e+00</second>
+						<second>-6.89719743833630772e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.93921397284129542e-02</second>
+						<second>3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.65804350658088406e+00</second>
+						<second>-1.65798172040915825e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88344875480654794e+00</score>
+				<score>1.88965318619784411e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28301,31 +28301,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85805360557982602e+00</second>
+						<second>1.90688714724360420e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.75689468355472123e+00</second>
+						<second>2.62568492148069155e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64063811762531331e+00</second>
+						<second>-1.62594994676778737e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.94618515104317380e+00</second>
+						<second>-2.07520682797054024e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.57506152855927795e-01</second>
+						<second>2.32802056144503711e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14149939473886430e+00</second>
+						<second>3.11740535949788722e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.72739521482828651e-01</second>
+						<second>7.72613168753316870e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28333,34 +28333,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77079723307309278e+00</second>
+						<second>-1.90013486377752305e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.72152087045429569e+00</second>
+						<second>2.06100226172179435e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.49050615547571086e+00</second>
+						<second>1.44995476228843456e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.03707803166231427e+00</second>
+						<second>-2.24469959305777333e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.84700133661556642e-01</second>
+						<second>-7.58904097980872661e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.94490743873896488e+00</second>
+						<second>1.10820246766059560e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.27428990918365015e+00</second>
+						<second>-1.27423640319262366e+00</second>
 					</item>
 				</goal_state>
-				<score>3.24004368493468231e+00</score>
+				<score>2.08283655444975346e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28391,31 +28391,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80048301098270747e+00</second>
+						<second>1.76432817561318123e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84968805161785999e+00</second>
+						<second>2.11712100485856397e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84748430205586645e+00</second>
+						<second>-1.53271451812852777e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.46332549145983482e-01</second>
+						<second>-2.06168832613968123e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.98662348788025467e+00</second>
+						<second>2.22295139329342017e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.20534791554624299e+00</second>
+						<second>2.90592092287403103e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.71109707139616929e+00</second>
+						<second>6.42331693122109026e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28423,34 +28423,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.82941622077009791e+00</second>
+						<second>1.91971078423910901e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.88088986423977245e+00</second>
+						<second>-1.69326286021334993e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.78605790741710413e+00</second>
+						<second>-1.64865919516368464e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.83761554474239697e-01</second>
+						<second>2.66318434326514009e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.80387166321470271e+00</second>
+						<second>2.83434441791442060e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.25456778980536288e+00</second>
+						<second>-1.74324732117652270e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44918559034931538e+00</second>
+						<second>1.44910393801641724e+00</second>
 					</item>
 				</goal_state>
-				<score>3.20796298364267729e+00</score>
+				<score>2.04098352256396193e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28481,31 +28481,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60176987721037456e+00</second>
+						<second>1.90027721862750276e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-7.45731572692133055e-02</second>
+						<second>-9.41233110306930881e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.36846937573378558e+00</second>
+						<second>1.33619557762236463e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.54855432878719546e-01</second>
+						<second>8.62490195606291254e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.18143121899762260e+00</second>
+						<second>-7.73491906301295495e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.40819129955978550e-01</second>
+						<second>3.11972931924754437e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.33444492832379469e-01</second>
+						<second>-1.13897893672029671e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28513,34 +28513,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69842527437781610e+00</second>
+						<second>1.67577807914305432e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-9.92130704492299453e-02</second>
+						<second>-5.48052426609956303e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.00863692662598292e+00</second>
+						<second>1.00680580761082372e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.42238626169744853e-01</second>
+						<second>9.69902869802193646e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.30919294546896570e+00</second>
+						<second>-8.60396210463838851e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.35519750969554569e-02</second>
+						<second>3.13412732235433911e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49960548086532408e+00</second>
+						<second>-1.49959099682830943e+00</second>
 					</item>
 				</goal_state>
-				<score>3.13203462616953177e+00</score>
+				<score>1.99337392297207011e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28571,31 +28571,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85805360557982602e+00</second>
+						<second>1.90688714724360420e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.75689468355472123e+00</second>
+						<second>2.62568492148069155e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64063811762531331e+00</second>
+						<second>-1.62594994676778737e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.94618515104317380e+00</second>
+						<second>-2.07520682797054024e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.57506152855927795e-01</second>
+						<second>2.32802056144503711e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14149939473886430e+00</second>
+						<second>3.11740535949788722e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.72739521482828651e-01</second>
+						<second>7.72613168753316870e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28603,34 +28603,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.70532887478218864e+00</second>
+						<second>1.87533383234688178e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.85043042302404181e+00</second>
+						<second>-3.90612984921867579e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.35530166467592417e+00</second>
+						<second>-1.33449747780527028e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.93134620162400972e+00</second>
+						<second>-2.22708873077543723e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-9.71353674829156133e-01</second>
+						<second>2.33968097845349776e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.04517589367200125e+00</second>
+						<second>3.14130384645203442e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.13907202439606658e+00</second>
+						<second>1.13877553686418276e+00</second>
 					</item>
 				</goal_state>
-				<score>2.97595483397852423e+00</score>
+				<score>2.07861022724096373e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28661,31 +28661,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.76432817561318123e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.11712100485856397e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.53271451812852777e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.06168832613968123e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.22295139329342017e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.90592092287403103e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>6.42331693122109026e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28693,34 +28693,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85805360557982602e+00</second>
+						<second>1.90617550849617645e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.75689468355472123e+00</second>
+						<second>2.64196302917744208e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64063811762531331e+00</second>
+						<second>-1.62595837839485302e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.94618515104317380e+00</second>
+						<second>-2.07350983664597210e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.57506152855927795e-01</second>
+						<second>2.32737894542490764e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14149939473886430e+00</second>
+						<second>3.11778055941738996e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.72739521482828651e-01</second>
+						<second>7.72989013691383176e-01</second>
 					</item>
 				</goal_state>
-				<score>2.59969201292127350e+00</score>
+				<score>1.65568251152902218e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28751,31 +28751,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78773248346576441e+00</second>
+						<second>-1.63087443996577219e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.77837666166757424e+00</second>
+						<second>7.32642053730761078e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.79446502359811144e+00</second>
+						<second>1.59595235845316585e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.78973881227557063e-01</second>
+						<second>-9.94464808720517901e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.66580929203518568e+00</second>
+						<second>-8.26399506822615537e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.04684989523332916e+00</second>
+						<second>1.09552046246619628e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.04573451725265532e+00</second>
+						<second>7.85889506309931929e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28783,34 +28783,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.79690243135123939e+00</second>
+						<second>-1.74607919774644826e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.99895877951538581e+00</second>
+						<second>9.98799827935420215e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.59349018850455471e+00</second>
+						<second>1.65047892423963249e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.61671754468278306e-01</second>
+						<second>-8.10277060590462228e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.49004642236794016e+00</second>
+						<second>-6.82949695314550631e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.00722778006336489e+00</second>
+						<second>-1.06445215219560674e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.35672834107230789e-01</second>
+						<second>9.35130022634869884e-01</second>
 					</item>
 				</goal_state>
-				<score>2.74544013012387067e+00</score>
+				<score>1.93482377536775801e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28841,31 +28841,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85561443089747624e+00</second>
+						<second>-1.91950548759046402e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.94924173106034626e+00</second>
+						<second>1.78319555790316953e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.68721554220585879e+00</second>
+						<second>1.57925257624761772e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.36615599819230549e-01</second>
+						<second>-3.17235558478556778e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.69542266508565564e+00</second>
+						<second>-4.76636735486730023e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.19322003540887067e+00</second>
+						<second>-8.23553698178268068e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32816737869660728e+00</second>
+						<second>1.04488548842742079e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28873,34 +28873,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91975139782178017e+00</second>
+						<second>-1.91969798646429135e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.61530546905488248e+00</second>
+						<second>1.52577029312792178e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.53904101949741046e+00</second>
+						<second>1.53930803431679819e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.59151008199688482e-01</second>
+						<second>-3.59730457042042095e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.62911373120048264e+00</second>
+						<second>-5.12567485633063868e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.75310105667776561e-01</second>
+						<second>-8.75652013025575826e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.08011791867018081e+00</second>
+						<second>1.07997444556590083e+00</second>
 					</item>
 				</goal_state>
-				<score>3.07006280327215197e+00</score>
+				<score>2.05655903022656628e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -28931,31 +28931,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80048301098270747e+00</second>
+						<second>-1.88083891289776073e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84968805161785999e+00</second>
+						<second>1.42878455810808269e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84748430205586645e+00</second>
+						<second>1.72407698201936510e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.46332549145983482e-01</second>
+						<second>-5.05227494400545263e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.98662348788025467e+00</second>
+						<second>-1.28051737692515044e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.20534791554624299e+00</second>
+						<second>1.33353865473624000e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.71109707139616929e+00</second>
+						<second>1.71103571847670222e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -28963,34 +28963,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91754913755242162e+00</second>
+						<second>-1.89062853030974298e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.36744180198839604e+00</second>
+						<second>2.47812374602058849e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.58381731597348807e+00</second>
+						<second>1.29215642101211614e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.27813500556508708e-01</second>
+						<second>4.60230709884764666e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.66623175791702449e+00</second>
+						<second>-6.56752624293201803e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.28905584564159859e-01</second>
+						<second>-4.06282424888026517e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.04547202754940094e+00</second>
+						<second>1.04555269621878000e+00</second>
 					</item>
 				</goal_state>
-				<score>2.95464529793425212e+00</score>
+				<score>2.03824709086663836e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -29021,31 +29021,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85805360557982602e+00</second>
+						<second>1.90688714724360420e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.75689468355472123e+00</second>
+						<second>2.62568492148069155e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64063811762531331e+00</second>
+						<second>-1.62594994676778737e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.94618515104317380e+00</second>
+						<second>-2.07520682797054024e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.57506152855927795e-01</second>
+						<second>2.32802056144503711e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14149939473886430e+00</second>
+						<second>3.11740535949788722e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.72739521482828651e-01</second>
+						<second>7.72613168753316870e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -29053,34 +29053,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.81748038472686546e+00</second>
+						<second>1.76432817561318123e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.05483179002218712e-02</second>
+						<second>2.11712100485856397e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.52649683277555126e+00</second>
+						<second>-1.53271451812852777e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.95974397519865740e-01</second>
+						<second>-2.06168832613968123e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.27705592182947392e+00</second>
+						<second>2.22295139329342017e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.71899846432171077e-01</second>
+						<second>2.90592092287403103e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.41654345881488952e-01</second>
+						<second>6.42331693122109026e-01</second>
 					</item>
 				</goal_state>
-				<score>2.16823251488438951e+00</score>
+				<score>1.50678625955759787e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -29111,31 +29111,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.56462825203793021e+00</second>
+						<second>-1.56090686850074256e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.15610684099707095e+00</second>
+						<second>8.65711298706078547e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.71305861025194162e+00</second>
+						<second>1.59716568055840979e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.32983370913493371e+00</second>
+						<second>-7.99928111239701312e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.42867529052722730e+00</second>
+						<second>-7.86596714875529068e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.83677130336604399e+00</second>
+						<second>1.15593703262247849e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.43433687284591116e-01</second>
+						<second>7.90846383785591023e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -29143,34 +29143,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.48923496664104738e+00</second>
+						<second>-1.47784374312398392e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.25065311632395559e+00</second>
+						<second>8.31696445979923205e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.41434574949438252e+00</second>
+						<second>1.42550387798338285e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44687790582781695e+00</second>
+						<second>-7.53418848014226206e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.24143394036810983e+00</second>
+						<second>-9.09934068372391547e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.98500457715291523e+00</second>
+						<second>1.14356427137096262e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>5.19425780294794914e-01</second>
+						<second>5.19386002032426020e-01</second>
 					</item>
 				</goal_state>
-				<score>1.80804794091836873e+00</score>
+				<score>1.22674471404458224e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -29201,31 +29201,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85561443089747624e+00</second>
+						<second>-1.84459178394975121e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.94924173106034626e+00</second>
+						<second>1.08609943140995324e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.68721554220585879e+00</second>
+						<second>1.58745100595908295e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.36615599819230549e-01</second>
+						<second>-6.18984881651324037e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.69542266508565564e+00</second>
+						<second>-5.41546128749344713e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.19322003540887067e+00</second>
+						<second>1.08200643783924799e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32816737869660728e+00</second>
+						<second>1.22486381748406625e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -29233,34 +29233,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.63223108688898666e+00</second>
+						<second>-1.62204581966640293e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.01777752284855882e+00</second>
+						<second>1.08102467888642284e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.51494615570768176e+00</second>
+						<second>1.52946483624860585e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-5.45570727533466138e-01</second>
+						<second>-5.88249462009932333e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.40847590031933034e+00</second>
+						<second>-7.40633536068927234e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.24525430535861514e+00</second>
+						<second>1.22929089651799295e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.90981838959245120e-01</second>
+						<second>7.90779347791297660e-01</second>
 					</item>
 				</goal_state>
-				<score>2.57147490887186558e+00</score>
+				<score>1.74334388783651761e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -29291,31 +29291,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85561443089747624e+00</second>
+						<second>-1.89787899410282890e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.94924173106034626e+00</second>
+						<second>1.81279535441363127e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.68721554220585879e+00</second>
+						<second>1.29484195659837575e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.36615599819230549e-01</second>
+						<second>8.39429106916729367e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.69542266508565564e+00</second>
+						<second>-6.23712761038971775e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.19322003540887067e+00</second>
+						<second>-6.57744086501373726e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32816737869660728e+00</second>
+						<second>9.35261384482846458e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -29323,34 +29323,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.62646346208097903e+00</second>
+						<second>-1.66972115122439724e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.95370442611607364e+00</second>
+						<second>1.37019035644148257e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.64150544259169817e+00</second>
+						<second>1.57083181469832045e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.17344369057844400e-01</second>
+						<second>-4.35853647248169940e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.46639989721338759e+00</second>
+						<second>-6.53883680261061251e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.37605961510617480e+00</second>
+						<second>1.45070056751875698e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.43361859118155310e-01</second>
+						<second>8.43404534473599532e-01</second>
 					</item>
 				</goal_state>
-				<score>2.79220939138916702e+00</score>
+				<score>1.83022608301673440e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -29381,31 +29381,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85561443089747624e+00</second>
+						<second>-1.89787899410282890e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.94924173106034626e+00</second>
+						<second>1.81279535441363127e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.68721554220585879e+00</second>
+						<second>1.29484195659837575e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.36615599819230549e-01</second>
+						<second>8.39429106916729367e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.69542266508565564e+00</second>
+						<second>-6.23712761038971775e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.19322003540887067e+00</second>
+						<second>-6.57744086501373726e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32816737869660728e+00</second>
+						<second>9.35261384482846458e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -29413,34 +29413,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74753649668544342e+00</second>
+						<second>-1.74732135476903561e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.04791145152498433e+00</second>
+						<second>2.06432495292301299e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.51338568980158206e+00</second>
+						<second>1.52105886708960258e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-4.49056752460664458e-03</second>
+						<second>-3.50606643989405178e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.41245183190154533e+00</second>
+						<second>-7.24899578201088413e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-7.23523336408422812e-01</second>
+						<second>-7.34116922466054422e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.33154400576498855e-01</second>
+						<second>6.33081695737913286e-01</second>
 					</item>
 				</goal_state>
-				<score>2.15353501873858999e+00</score>
+				<score>1.51244318305489289e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -31181,31 +31181,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.53153345297258481e+00</second>
+						<second>-1.74735381940090728e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.73943185941435696e-01</second>
+						<second>-6.70896556800725352e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64748772216048933e+00</second>
+						<second>1.64071130923695541e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.24390878253930492e+00</second>
+						<second>6.07364678260328472e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.06621847443260465e-01</second>
+						<second>5.06616863199255696e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.04786014836411012e+00</second>
+						<second>-5.91291261898572618e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.81651032287610903e-01</second>
+						<second>1.59163612621125039e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -31213,34 +31213,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.50527518949420713e+00</second>
+						<second>-1.58040110349517282e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.57686113309499765e-01</second>
+						<second>-7.84172502851111730e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.43028405084706534e+00</second>
+						<second>1.38740470089379264e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.22856019152355644e+00</second>
+						<second>8.96691822429125929e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.99573877707567893e-01</second>
+						<second>9.38865821345401197e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.09764371279093997e+00</second>
+						<second>-1.13968878131320417e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.70755720247307163e-01</second>
+						<second>4.70564890371103217e-01</second>
 					</item>
 				</goal_state>
-				<score>1.65021444059937239e+00</score>
+				<score>1.13364646091204183e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -31271,31 +31271,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61769388841950512e+00</second>
+						<second>-1.74735381940090728e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.38848308169308821e+00</second>
+						<second>-6.70896556800725352e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91602565380586687e+00</second>
+						<second>1.64071130923695541e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.09383642848697082e+00</second>
+						<second>6.07364678260328472e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.53563760309345865e+00</second>
+						<second>5.06616863199255696e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.15840472683926254e+00</second>
+						<second>-5.91291261898572618e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32188649050487128e+00</second>
+						<second>1.59163612621125039e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -31303,34 +31303,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61628137603042710e+00</second>
+						<second>-1.65479375952283481e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.45042140993734003e+00</second>
+						<second>-7.97071899665351746e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.60351359758469392e+00</second>
+						<second>1.57663576759233748e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.10586465725776195e+00</second>
+						<second>9.31054588739472777e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.30188418143135687e+00</second>
+						<second>8.10621412509582973e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.05482021228547440e+00</second>
+						<second>-1.11225199207082426e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.81726973125779878e-01</second>
+						<second>7.81782360019167899e-01</second>
 					</item>
 				</goal_state>
-				<score>2.46427520873712513e+00</score>
+				<score>1.73759589943931120e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -31451,31 +31451,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36234264325357590e+00</second>
+						<second>-1.64831557231393666e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.08630571727141700e-01</second>
+						<second>2.75805752612921928e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.74558457735316463e-01</second>
+						<second>-1.26218509375873889e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.87467967159666782e-01</second>
+						<second>6.79717554929587409e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.02828768302830720e+00</second>
+						<second>-2.42223985436096401e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.69672469130647841e-01</second>
+						<second>-3.04788337158437506e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.55924194813239925e-01</second>
+						<second>1.22306911270273755e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -31483,34 +31483,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.37868660879675220e+00</second>
+						<second>-1.42064745241965595e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.40007595017355890e-01</second>
+						<second>2.60707001851858866e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.02958257629769623e+00</second>
+						<second>-1.01025654298658596e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.02398841271607077e+00</second>
+						<second>8.11288350890397747e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.04055737191193343e+00</second>
+						<second>-2.14904539817734674e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-6.50208787367546726e-01</second>
+						<second>-6.82721571212758449e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.41354093869825770e-01</second>
+						<second>4.41122384543384094e-01</second>
 					</item>
 				</goal_state>
-				<score>1.35611262663608856e+00</score>
+				<score>8.67847054280304758e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -31541,31 +31541,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64897472331619266e+00</second>
+						<second>-1.64831557231393666e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.75684221840775701e+00</second>
+						<second>2.75805752612921928e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.26186096548384352e+00</second>
+						<second>-1.26218509375873889e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46347914774312660e+00</second>
+						<second>6.79717554929587409e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.42320873423233873e+00</second>
+						<second>-2.42223985436096401e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83607947958971174e+00</second>
+						<second>-3.04788337158437506e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22318107600518799e+00</second>
+						<second>1.22306911270273755e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -31573,34 +31573,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.54793393782259581e+00</second>
+						<second>-1.54737425223645841e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.63173912551387357e+00</second>
+						<second>2.63314552490189957e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.25674152769054825e+00</second>
+						<second>-1.25706383741706840e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.33053804203208292e+00</second>
+						<second>8.12585237455080933e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.26814503634882536e+00</second>
+						<second>-2.26753815754620280e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.53788891515888571e+00</second>
+						<second>-6.03172474370826883e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.56754616469535990e-01</second>
+						<second>8.56754944443759214e-01</second>
 					</item>
 				</goal_state>
-				<score>2.54792321953025480e+00</score>
+				<score>1.64814356142660101e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -31631,31 +31631,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64897472331619266e+00</second>
+						<second>-1.64831557231393666e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.75684221840775701e+00</second>
+						<second>2.75805752612921928e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.26186096548384352e+00</second>
+						<second>-1.26218509375873889e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46347914774312660e+00</second>
+						<second>6.79717554929587409e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.42320873423233873e+00</second>
+						<second>-2.42223985436096401e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83607947958971174e+00</second>
+						<second>-3.04788337158437506e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22318107600518799e+00</second>
+						<second>1.22306911270273755e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -31663,34 +31663,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.59467879450421957e+00</second>
+						<second>-1.59394248802745997e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.60836799020910970e+00</second>
+						<second>2.60982320004198565e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.45915637718895019e+00</second>
+						<second>-1.45957791076652765e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.27875242441330483e+00</second>
+						<second>8.64306351681498497e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.33501734742509770e+00</second>
+						<second>-2.33429807409058032e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.51028362539048766e+00</second>
+						<second>-6.30679461006336317e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.08377819807085096e+00</second>
+						<second>1.08377885010957331e+00</second>
 					</item>
 				</goal_state>
-				<score>3.03003103977268218e+00</score>
+				<score>1.96313958969134200e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -31721,31 +31721,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61769388841950512e+00</second>
+						<second>-1.75069793322412259e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.38848308169308821e+00</second>
+						<second>-6.07138823785259962e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91602565380586687e+00</second>
+						<second>1.46364746255148592e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.09383642848697082e+00</second>
+						<second>5.64446874933644982e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.53563760309345865e+00</second>
+						<second>5.71210030361101073e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.15840472683926254e+00</second>
+						<second>-5.17509800218195037e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32188649050487128e+00</second>
+						<second>1.44029864320904633e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -31753,34 +31753,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64093076962699436e+00</second>
+						<second>-1.70372217991790920e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.50967640588486063e+00</second>
+						<second>-7.52797278528037128e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.61759321053386107e+00</second>
+						<second>1.57121858852798657e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.24879611565712656e+00</second>
+						<second>7.75509548815249694e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.40898542420573980e+00</second>
+						<second>6.76770418261484985e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.39496454987968033e+00</second>
+						<second>-8.03768546119409732e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.19617507519897037e+00</second>
+						<second>1.19615678694974026e+00</second>
 					</item>
 				</goal_state>
-				<score>3.29176845995357858e+00</score>
+				<score>2.07119248642091996e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -31811,31 +31811,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.70865062545103608e+00</second>
+						<second>-1.90824652356106284e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.17344875257580172e+00</second>
+						<second>-1.45356340015587637e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91889357973545738e+00</second>
+						<second>1.57421548795214261e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.37407948854525985e+00</second>
+						<second>4.43948224189707696e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.80802910408089268e+00</second>
+						<second>5.25389380485719815e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20895421388375013e+00</second>
+						<second>9.02835849719668904e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.67032604693571773e+00</second>
+						<second>1.06235146506180711e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -31843,34 +31843,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.76082921697254369e+00</second>
+						<second>-1.75898434222349120e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.23571126487810057e+00</second>
+						<second>-9.02181748462884237e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.67717354907443927e+00</second>
+						<second>1.67888200187009162e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.32955010971975174e+00</second>
+						<second>8.15671444567647730e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.53334429239486258e+00</second>
+						<second>6.09617182952577052e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.15216559477337110e+00</second>
+						<second>-9.87758593309020827e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.20887095432987457e+00</second>
+						<second>1.20884613498187687e+00</second>
 					</item>
 				</goal_state>
-				<score>3.15568513832345676e+00</score>
+				<score>2.09122248050696319e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -31901,31 +31901,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77056668024924546e+00</second>
+						<second>-1.90664712158350813e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.07088825417249245e+00</second>
+						<second>-1.32914218320266775e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.88372806912077628e+00</second>
+						<second>1.62527095779734565e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.58492626658123026e+00</second>
+						<second>3.04039462352498346e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-3.06746848505459102e+00</second>
+						<second>-2.77467252524193804e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.21224315502393232e+00</second>
+						<second>-1.23420333828543027e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95033305200882157e+00</second>
+						<second>1.95032560574722491e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -31933,34 +31933,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.80543311468609735e+00</second>
+						<second>-1.91969420424220027e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.05394518815942773e+00</second>
+						<second>-1.34143165395993691e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75272151513511765e+00</second>
+						<second>1.59422208033113022e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.38947657219905762e+00</second>
+						<second>4.77762818056693406e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.66399234032112409e+00</second>
+						<second>4.18536670174532666e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.00827696029826619e+00</second>
+						<second>-1.30162574130794817e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32182745107173005e+00</second>
+						<second>1.32156259658802422e+00</second>
 					</item>
 				</goal_state>
-				<score>3.22755161028517534e+00</score>
+				<score>2.09627044609279667e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -31991,31 +31991,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.66066501829163360e+00</second>
+						<second>-1.71079613020848686e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81983341164286960e+00</second>
+						<second>2.82103879031056382e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.15459929940201778e+00</second>
+						<second>-1.31091010038959488e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51672498306495340e+00</second>
+						<second>6.35313702935619840e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.46768754438344295e+00</second>
+						<second>-2.50800822094248144e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.93849379968647062e+00</second>
+						<second>-1.85727001275092646e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.21428875815116966e+00</second>
+						<second>1.42477258574310017e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32023,34 +32023,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.57091295634294092e+00</second>
+						<second>-1.56812413193305811e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.69931498690806526e+00</second>
+						<second>2.70553616965288413e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.18417883286046810e+00</second>
+						<second>-1.18569936183493452e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.42359385619014889e+00</second>
+						<second>7.25625933661714129e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.32876080016412912e+00</second>
+						<second>-2.32514238669507600e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.70553644953476224e+00</second>
+						<second>-4.33032964995497927e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.66565966861221537e-01</second>
+						<second>9.66355700104456705e-01</second>
 					</item>
 				</goal_state>
-				<score>2.67899184079623343e+00</score>
+				<score>1.68066087789964819e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32081,31 +32081,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64897472331619266e+00</second>
+						<second>-1.77815116686493502e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.75684221840775701e+00</second>
+						<second>2.87671728343350264e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.26186096548384352e+00</second>
+						<second>-1.43370101909979542e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46347914774312660e+00</second>
+						<second>5.83954684841631821e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.42320873423233873e+00</second>
+						<second>-2.60717139581401325e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83607947958971174e+00</second>
+						<second>-9.20091045913934980e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22318107600518799e+00</second>
+						<second>1.68214978546571925e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32113,34 +32113,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63789170127869665e+00</second>
+						<second>-1.63526909203519533e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.72265959196362317e+00</second>
+						<second>2.72746381956571549e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33038523130822028e+00</second>
+						<second>-1.33175346602044864e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.43139997145057940e+00</second>
+						<second>7.15532911267066529e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.40184537534954812e+00</second>
+						<second>-2.39854975156820904e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.77026608971712918e+00</second>
+						<second>-3.68271418672615036e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22576411079849779e+00</second>
+						<second>1.22571282105652712e+00</second>
 					</item>
 				</goal_state>
-				<score>3.06098279374594773e+00</score>
+				<score>1.91753227294250872e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32171,31 +32171,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.69660054933453841e+00</second>
+						<second>-1.64831557231393666e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.71568389803189802e+00</second>
+						<second>2.75805752612921928e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75837516174439479e+00</second>
+						<second>-1.26218509375873889e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.45730340318644647e+00</second>
+						<second>6.79717554929587409e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.62338287279903648e+00</second>
+						<second>-2.42223985436096401e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83246440329905003e+00</second>
+						<second>-3.04788337158437506e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82028058326015829e+00</second>
+						<second>1.22306911270273755e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32203,34 +32203,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.66324183031696138e+00</second>
+						<second>-1.65552713370598692e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.68999615578065532e+00</second>
+						<second>2.70192540624460786e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.52660958446832073e+00</second>
+						<second>-1.53089180503875988e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.41595980571103564e+00</second>
+						<second>7.37223235945965727e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.46232407944029097e+00</second>
+						<second>-2.45395856929629774e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.74134721652886393e+00</second>
+						<second>-3.91598535560690908e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44021273733013278e+00</second>
+						<second>1.44055272998604078e+00</second>
 					</item>
 				</goal_state>
-				<score>3.17007047239096318e+00</score>
+				<score>1.98580561190644378e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32261,31 +32261,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.68304180521979796e+00</second>
+						<second>-1.79330644393967753e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.53365607891304689e+00</second>
+						<second>-5.80965359360368194e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91963070841924233e+00</second>
+						<second>1.68956099489470901e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.47098096580177762e+00</second>
+						<second>5.55521317919442592e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.76847589017741891e+00</second>
+						<second>3.91854576093256968e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.64281535957950764e+00</second>
+						<second>-4.46484910450522687e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91448193145372647e+00</second>
+						<second>1.82027581635473124e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32293,34 +32293,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.70299771536135802e+00</second>
+						<second>-1.73397304913917072e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.54776187788791431e+00</second>
+						<second>-6.47186759416119028e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.67816476860129482e+00</second>
+						<second>1.65279578022075957e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46313977189441324e+00</second>
+						<second>6.29822877890726440e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.58374943579392680e+00</second>
+						<second>5.22196234281519733e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.60984221714968312e+00</second>
+						<second>-5.72733833153276861e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.59165367273433911e+00</second>
+						<second>1.59166485457381168e+00</second>
 					</item>
 				</goal_state>
-				<score>3.07327955843602130e+00</score>
+				<score>1.92568870809678383e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32351,31 +32351,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.70865062545103608e+00</second>
+						<second>-1.89648468844720419e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.17344875257580172e+00</second>
+						<second>-1.28240364971678300e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91889357973545738e+00</second>
+						<second>1.63311863227613752e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.37407948854525985e+00</second>
+						<second>5.45450328001642615e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.80802910408089268e+00</second>
+						<second>4.28615433619086772e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20895421388375013e+00</second>
+						<second>-1.25806031189375478e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.67032604693571773e+00</second>
+						<second>1.32194818522629132e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32383,34 +32383,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.76343536150351610e+00</second>
+						<second>-1.89583086006454238e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.28917221203157073e+00</second>
+						<second>-1.12673254649557952e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.76356426267541155e+00</second>
+						<second>1.56028154179690226e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51694194520703185e+00</second>
+						<second>3.40153340732389120e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.74860638873879193e+00</second>
+						<second>2.59383397451259379e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.36622373415104859e+00</second>
+						<second>-1.03507176220791286e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.67186848616890305e+00</second>
+						<second>1.67185137843167086e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88103207717149568e+00</score>
+				<score>1.85185264505358327e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32441,31 +32441,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77056668024924546e+00</second>
+						<second>-1.90664712158350813e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.07088825417249245e+00</second>
+						<second>-1.32914218320266775e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.88372806912077628e+00</second>
+						<second>1.62527095779734565e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.58492626658123026e+00</second>
+						<second>3.04039462352498346e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-3.06746848505459102e+00</second>
+						<second>-2.77467252524193804e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.21224315502393232e+00</second>
+						<second>-1.23420333828543027e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95033305200882157e+00</second>
+						<second>1.95032560574722491e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32473,34 +32473,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.78806346143353867e+00</second>
+						<second>-1.91979914068060187e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.04455237902934917e+00</second>
+						<second>-1.35097187145235265e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.82930748460479142e+00</second>
+						<second>1.61827060801311373e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48374742953864791e+00</second>
+						<second>3.90690169194173875e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.86426652995970032e+00</second>
+						<second>2.00350103144000286e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11474088779904079e+00</second>
+						<second>-1.26193069488316234e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.67060792421692006e+00</second>
+						<second>1.67058483918596035e+00</second>
 					</item>
 				</goal_state>
-				<score>2.79943380847459355e+00</score>
+				<score>1.85417003884253390e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32531,31 +32531,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67036370632477005e+00</second>
+						<second>-1.87772022235495495e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.82911906499151034e+00</second>
+						<second>-1.29548472950598059e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>7.77050033334609092e-01</second>
+						<second>1.64598978156509834e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.96846753830387078e-01</second>
+						<second>2.52267512988913312e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.40337133149682125e-01</second>
+						<second>-2.37125744556079876e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.68117414603628257e+00</second>
+						<second>-1.21440278102445620e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.92781996704816128e+00</second>
+						<second>2.14039149926916972e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32563,34 +32563,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68164349903212140e+00</second>
+						<second>-1.91230019528574413e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.79808063012355879e+00</second>
+						<second>-1.49374990415161735e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.49061836099290979e-01</second>
+						<second>1.66414087992335857e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.00001141701076612e-01</second>
+						<second>4.33163864627272688e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.50194916847385063e-01</second>
+						<second>1.22566615509941287e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.53481305049739625e+00</second>
+						<second>-1.40190130710026795e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70871991830956271e+00</second>
+						<second>1.70859747191160460e+00</second>
 					</item>
 				</goal_state>
-				<score>2.69313067319763322e+00</score>
+				<score>1.79604765688076012e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32621,31 +32621,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.69660054933453841e+00</second>
+						<second>-1.64831557231393666e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.71568389803189802e+00</second>
+						<second>2.75805752612921928e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75837516174439479e+00</second>
+						<second>-1.26218509375873889e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.45730340318644647e+00</second>
+						<second>6.79717554929587409e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.62338287279903648e+00</second>
+						<second>-2.42223985436096401e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83246440329905003e+00</second>
+						<second>-3.04788337158437506e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82028058326015829e+00</second>
+						<second>1.22306911270273755e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32653,34 +32653,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73110566756165651e+00</second>
+						<second>-1.71800651861345655e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.77635814861694863e+00</second>
+						<second>2.79662075647242636e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.39449278697979873e+00</second>
+						<second>-1.40101658671634177e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51253552210635211e+00</second>
+						<second>6.52228664642289124e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.53253797949373061e+00</second>
+						<second>-2.51461347421414860e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.90805007464500065e+00</second>
+						<second>-2.15808298853520708e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49988536014197904e+00</second>
+						<second>1.49984576548134019e+00</second>
 					</item>
 				</goal_state>
-				<score>3.01336339798945607e+00</score>
+				<score>1.88734558573648181e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32711,31 +32711,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.75129634502055831e+00</second>
+						<second>-1.64831557231393666e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.80861340612210508e+00</second>
+						<second>2.75805752612921928e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.77186493257984434e+00</second>
+						<second>-1.26218509375873889e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.56910839403016800e+00</second>
+						<second>6.79717554929587409e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.72918533337231661e+00</second>
+						<second>-2.42223985436096401e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.96770492719931989e+00</second>
+						<second>-3.04788337158437506e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.99583234667512244e+00</second>
+						<second>1.22306911270273755e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32743,34 +32743,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74282958880292793e+00</second>
+						<second>-1.72638356720173780e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.75844943569293477e+00</second>
+						<second>2.78285673490142971e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.54703146873696928e+00</second>
+						<second>-1.55547120640441672e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50270282851143255e+00</second>
+						<second>6.62920422387868635e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.58010848899250789e+00</second>
+						<second>-2.55860787118103428e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.89485603392070834e+00</second>
+						<second>-2.24860522950153324e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.66895094830176571e+00</second>
+						<second>1.66905577575253239e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88489552071470179e+00</score>
+				<score>1.80843294237830687e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32801,31 +32801,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.68304180521979796e+00</second>
+						<second>-1.80575802684637798e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.53365607891304689e+00</second>
+						<second>-4.94181323594012234e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91963070841924233e+00</second>
+						<second>1.34354914312485874e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.47098096580177762e+00</second>
+						<second>4.71787527283302699e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.76847589017741891e+00</second>
+						<second>4.95843555530206759e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.64281535957950764e+00</second>
+						<second>-3.57339993812716195e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91448193145372647e+00</second>
+						<second>1.49985809487429145e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32833,34 +32833,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.76398657928587554e+00</second>
+						<second>-1.79330644393967753e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.60920923447049757e+00</second>
+						<second>-5.80965359360368194e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.71383381515993194e+00</second>
+						<second>1.68956099489470901e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.54305638368413778e+00</second>
+						<second>5.55521317919442592e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.71059951897959728e+00</second>
+						<second>3.91854576093256968e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.74106147689688129e+00</second>
+						<second>-4.46484910450522687e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82038492126933282e+00</second>
+						<second>1.82027581635473124e+00</second>
 					</item>
 				</goal_state>
-				<score>2.64604503973686933e+00</score>
+				<score>1.65659617828493061e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32891,31 +32891,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74785716738495633e+00</second>
+						<second>-1.87772022235495495e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.56418273366954308e+00</second>
+						<second>-1.29548472950598059e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91932273245387908e+00</second>
+						<second>1.64598978156509834e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.62952977680462086e+00</second>
+						<second>2.52267512988913312e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.94376985628729804e+00</second>
+						<second>-2.37125744556079876e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71528210245107626e+00</second>
+						<second>-1.21440278102445620e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.10140549116757347e+00</second>
+						<second>2.14039149926916972e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -32923,34 +32923,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71489693352731076e+00</second>
+						<second>-1.91143839745425836e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.48138237356416980e+00</second>
+						<second>-1.03629857753289700e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.89295844814681269e+00</second>
+						<second>1.61479732850674251e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50584235246842679e+00</second>
+						<second>2.96639515668864817e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.80701950340557760e+00</second>
+						<second>8.72836714228682337e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.60033381886341974e+00</second>
+						<second>-9.37245045659437448e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91467729556806998e+00</second>
+						<second>1.91459171058699873e+00</second>
 					</item>
 				</goal_state>
-				<score>2.39748128924333859e+00</score>
+				<score>1.51604621468059225e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -32981,31 +32981,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74785716738495633e+00</second>
+						<second>-1.87772022235495495e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.56418273366954308e+00</second>
+						<second>-1.29548472950598059e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91932273245387908e+00</second>
+						<second>1.64598978156509834e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.62952977680462086e+00</second>
+						<second>2.52267512988913312e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.94376985628729804e+00</second>
+						<second>-2.37125744556079876e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71528210245107626e+00</second>
+						<second>-1.21440278102445620e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.10140549116757347e+00</second>
+						<second>2.14039149926916972e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33013,34 +33013,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77133114828962057e+00</second>
+						<second>-1.91878869800007656e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.06962357440955902e+00</second>
+						<second>-1.36070435045604765e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.88263107656286777e+00</second>
+						<second>1.58968794733277452e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.58594869083390755e+00</second>
+						<second>2.67170457248482707e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-3.06810168357524304e+00</second>
+						<second>-3.58440555484355328e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.21098507136634126e+00</second>
+						<second>-1.27754336132031843e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95033756155668936e+00</second>
+						<second>1.95025217010170859e+00</second>
 					</item>
 				</goal_state>
-				<score>2.24219973155004393e+00</score>
+				<score>1.45498295659949456e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33071,31 +33071,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68382121771877924e+00</second>
+						<second>-1.87772022235495495e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.79366981286883442e+00</second>
+						<second>-1.29548472950598059e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.49970152778759314e-01</second>
+						<second>1.64598978156509834e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.97783892398964523e-01</second>
+						<second>2.52267512988913312e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.47260446361471509e-01</second>
+						<second>-2.37125744556079876e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.53276303456733309e+00</second>
+						<second>-1.21440278102445620e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70861024677965845e+00</second>
+						<second>2.14039149926916972e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33103,34 +33103,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67036370632477005e+00</second>
+						<second>-1.85323008416043611e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.82911906499151034e+00</second>
+						<second>-1.47698848428901641e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>7.77050033334609092e-01</second>
+						<second>1.72937766432704310e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.96846753830387078e-01</second>
+						<second>4.60852726536429114e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.40337133149682125e-01</second>
+						<second>-7.48632582290758436e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.68117414603628257e+00</second>
+						<second>-1.35103179962675068e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.92781996704816128e+00</second>
+						<second>1.92780317112841715e+00</second>
 					</item>
 				</goal_state>
-				<score>2.26450638514073832e+00</score>
+				<score>1.45976909329005866e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33161,31 +33161,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72204748035363431e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.76075294525565029e-02</second>
+						<second>-1.75035080538460758e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13160171529988962e+00</second>
+						<second>1.42795588243118177e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.17130728058755351e-01</second>
+						<second>3.05647721498500002e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.83063216325978018e-01</second>
+						<second>2.60795456632877676e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20359409465491096e-01</second>
+						<second>-3.68506029823346681e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49766408053323086e+00</second>
+						<second>1.88855792938110034e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33193,34 +33193,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67310653540599996e+00</second>
+						<second>-1.84358754801027169e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.26459961235604407e-01</second>
+						<second>-3.67944275182237490e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.46233704380274832e+00</second>
+						<second>1.39860833719397393e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.33736209359702629e-01</second>
+						<second>4.56672875912323861e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.79260708506280508e-01</second>
+						<second>4.25924250706604168e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.50301554233342588e-02</second>
+						<second>-2.09514297453478132e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68232513744266665e+00</second>
+						<second>1.68230841914353690e+00</second>
 					</item>
 				</goal_state>
-				<score>2.77278060301976348e+00</score>
+				<score>1.74620290246333104e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33251,31 +33251,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71470172889414507e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.26526806032483197e-02</second>
+						<second>-1.75035080538460758e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.46683742590182065e+00</second>
+						<second>1.42795588243118177e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.76315635410505656e-01</second>
+						<second>3.05647721498500002e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.24458336218553844e-01</second>
+						<second>2.60795456632877676e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.55751716007980795e-01</second>
+						<second>-3.68506029823346681e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79451859098775546e+00</second>
+						<second>1.88855792938110034e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33283,34 +33283,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67187990745811677e+00</second>
+						<second>-1.85521367637424106e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-9.39714242885946877e-02</second>
+						<second>-3.55042910847199633e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.58685812590623043e+00</second>
+						<second>1.52376119278046351e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.15785086422579653e-01</second>
+						<second>4.57939525111987600e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.51215462748223173e-01</second>
+						<second>3.76844584685266382e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>8.60682084978718481e-02</second>
+						<second>-1.92511043846017332e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.84022826065002842e+00</second>
+						<second>1.84025710788886876e+00</second>
 					</item>
 				</goal_state>
-				<score>2.52335750530583924e+00</score>
+				<score>1.59511112636802871e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33341,31 +33341,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.69660054933453841e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.71568389803189802e+00</second>
+						<second>-1.75035080538460758e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75837516174439479e+00</second>
+						<second>1.42795588243118177e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.45730340318644647e+00</second>
+						<second>3.05647721498500002e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.62338287279903648e+00</second>
+						<second>2.60795456632877676e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83246440329905003e+00</second>
+						<second>-3.68506029823346681e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82028058326015829e+00</second>
+						<second>1.88855792938110034e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33373,34 +33373,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.75129634502055831e+00</second>
+						<second>-1.79289706124245862e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.80861340612210508e+00</second>
+						<second>-4.02286668144251236e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.77186493257984434e+00</second>
+						<second>1.74718877413411233e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.56910839403016800e+00</second>
+						<second>5.19582051198902328e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.72918533337231661e+00</second>
+						<second>3.47127275439869265e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.96770492719931989e+00</second>
+						<second>-2.43636387452536352e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.99583234667512244e+00</second>
+						<second>1.99578732208242648e+00</second>
 					</item>
 				</goal_state>
-				<score>2.21805584198547034e+00</score>
+				<score>1.38847196547230600e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33431,31 +33431,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.69660054933453841e+00</second>
+						<second>-1.87772022235495495e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.71568389803189802e+00</second>
+						<second>-1.29548472950598059e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75837516174439479e+00</second>
+						<second>1.64598978156509834e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.45730340318644647e+00</second>
+						<second>2.52267512988913312e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.62338287279903648e+00</second>
+						<second>-2.37125744556079876e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83246440329905003e+00</second>
+						<second>-1.21440278102445620e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82028058326015829e+00</second>
+						<second>2.14039149926916972e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33463,34 +33463,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74785716738495633e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.56418273366954308e+00</second>
+						<second>-9.73997251035445433e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91932273245387908e+00</second>
+						<second>1.61703755829946738e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.62952977680462086e+00</second>
+						<second>1.73511537260771231e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.94376985628729804e+00</second>
+						<second>-1.12706526692207987e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71528210245107626e+00</second>
+						<second>-9.14478319573028164e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.10140549116757347e+00</second>
+						<second>2.10138856628978665e+00</second>
 					</item>
 				</goal_state>
-				<score>1.91392628560236422e+00</score>
+				<score>1.20137200191494264e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33521,31 +33521,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67036370632477005e+00</second>
+						<second>-1.85303504352993786e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.82911906499151034e+00</second>
+						<second>-1.47675941457086823e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>7.77050033334609092e-01</second>
+						<second>1.72971685532064878e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.96846753830387078e-01</second>
+						<second>4.61284625803758841e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.40337133149682125e-01</second>
+						<second>-7.48415551267118673e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.68117414603628257e+00</second>
+						<second>-1.35058203186015469e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.92781996704816128e+00</second>
+						<second>1.92777924308250914e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33553,34 +33553,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.48355791314392116e+00</second>
+						<second>-1.87772022235495495e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.81373189601179874e+00</second>
+						<second>-1.29548472950598059e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>4.87278810648397231e-01</second>
+						<second>1.64598978156509834e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.77479405340243312e-01</second>
+						<second>2.52267512988913312e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>3.97817092519894000e-01</second>
+						<second>-2.37125744556079876e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.69389238266661479e+00</second>
+						<second>-1.21440278102445620e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14040185681513728e+00</second>
+						<second>2.14039149926916972e+00</second>
 					</item>
 				</goal_state>
-				<score>1.58088281260714747e+00</score>
+				<score>1.12279072771163849e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33611,31 +33611,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69302807013186873e+00</second>
+						<second>1.90677101350841594e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.80084687925616693e+00</second>
+						<second>-2.96700000000000008e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12648455461922148e+00</second>
+						<second>1.16132762993560745e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.32644525729222318e+00</second>
+						<second>2.52869414024791794e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31287724919839022e+00</second>
+						<second>5.84693894201731346e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.91158706424462843e-01</second>
+						<second>-3.05324261388614815e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87548964152909536e+00</second>
+						<second>1.64523893003201716e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33643,34 +33643,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54146591030873847e+00</second>
+						<second>-1.67112941089740730e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>-2.96699985747430972e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.24629259158364958e-01</second>
+						<second>-7.24593750689819016e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44684139822691016e+00</second>
+						<second>2.53984108501410821e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.38291662796365422e+00</second>
+						<second>-2.66041708376390806e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.04354123181146452e+00</second>
+						<second>-2.87263375843483448e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.10510314143936172e+00</second>
+						<second>-2.10510161639243609e+00</second>
 					</item>
 				</goal_state>
-				<score>1.82090852553084082e+00</score>
+				<score>1.15257545795280830e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33701,31 +33701,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78637060988341356e+00</second>
+						<second>-1.77778840091602741e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.04721522689026075e-01</second>
+						<second>-5.50553056058490586e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.71036451288940472e+00</second>
+						<second>1.91929293613832441e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.56763737192674513e-01</second>
+						<second>2.92964542550782359e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.13248621962688190e-01</second>
+						<second>-2.71208712062013454e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.58036920870392184e-01</second>
+						<second>-4.31484917558331016e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19784145324850666e+00</second>
+						<second>2.24536994218442310e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33733,34 +33733,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75710114345983048e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>9.78689810643983138e-03</second>
+						<second>-2.56701582331737344e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.55873961545851691e+00</second>
+						<second>1.51855945438899842e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.85552513694617471e-01</second>
+						<second>2.95005417052568997e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.43777858502480393e-01</second>
+						<second>2.23172889391079127e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.25562014398732524e-01</second>
+						<second>-1.27992473376979166e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.96562695644893926e+00</second>
+						<second>1.96555842053219654e+00</second>
 					</item>
 				</goal_state>
-				<score>2.22036763216342559e+00</score>
+				<score>1.41145398588203519e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33791,31 +33791,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66925791581053873e+00</second>
+						<second>-1.87790646157441721e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-9.03095193771310256e-02</second>
+						<second>8.16073062843705038e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.58707722126778106e+00</second>
+						<second>1.73253012695474262e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.18505174331760643e-01</second>
+						<second>-1.30659944865078148e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.54922146744453260e-01</second>
+						<second>-8.61462304007950541e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>8.92168160214446004e-02</second>
+						<second>2.40036025761119452e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.84023930436279448e+00</second>
+						<second>2.19857969550768972e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33823,34 +33823,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68147037053225556e+00</second>
+						<second>-1.86557920155478008e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.68746030616156073e-02</second>
+						<second>-3.10988545377754944e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.77603932187852576e+00</second>
+						<second>1.72516681754824441e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.61335247594764497e-01</second>
+						<second>3.10322458417390479e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.39054718758122831e-01</second>
+						<second>1.68511841654202160e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.10959211558974680e-01</second>
+						<second>-1.86701554479861753e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.12704227996663553e+00</second>
+						<second>2.12704142722216538e+00</second>
 					</item>
 				</goal_state>
-				<score>1.84908834710682335e+00</score>
+				<score>1.16851907876526384e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -33881,31 +33881,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74464655436084648e+00</second>
+						<second>-1.86599507389824737e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.58802106428551483e-02</second>
+						<second>-3.12022481166436993e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.55839273722332639e+00</second>
+						<second>1.72480915032231485e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.00102572895211406e-01</second>
+						<second>3.09376102889009463e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.62897973861232526e-01</second>
+						<second>1.67388674299630669e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.44420032308462487e-01</second>
+						<second>-1.88096281174045532e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.96569910964345551e+00</second>
+						<second>2.12704651922756005e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -33913,34 +33913,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.24628822490843394e+00</second>
+						<second>-1.77778840091602741e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.51153637677357144e-01</second>
+						<second>-5.50553056058490586e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.91898034040003695e+00</second>
+						<second>1.91929293613832441e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.02532876186664512e-01</second>
+						<second>2.92964542550782359e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.85962431984410803e-01</second>
+						<second>-2.71208712062013454e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70931425880790488e-01</second>
+						<second>-4.31484917558331016e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.24541234239523213e+00</second>
+						<second>2.24536994218442310e+00</second>
 					</item>
 				</goal_state>
-				<score>1.41428471295579272e+00</score>
+				<score>9.52510098981775022e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -34061,31 +34061,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69302807013186873e+00</second>
+						<second>-1.77230653496244694e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.80084687925616693e+00</second>
+						<second>-7.33376172770565521e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12648455461922148e+00</second>
+						<second>-8.73595581161907497e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.32644525729222318e+00</second>
+						<second>-5.18625279468276856e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31287724919839022e+00</second>
+						<second>-2.62974880159214974e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.91158706424462843e-01</second>
+						<second>3.14149996087379124e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87548964152909536e+00</second>
+						<second>2.13510519039842128e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -34093,34 +34093,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.78755704503224244e+00</second>
+						<second>-1.65214130816754312e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.40983277476643387e+00</second>
+						<second>-1.31312973383891252e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.51296694592313496e+00</second>
+						<second>-7.12726592468092557e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.23169848335719712e-01</second>
+						<second>-4.78170112202087605e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-5.34067548553156191e-01</second>
+						<second>-2.61777930367190637e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.45057298933861367e+00</second>
+						<second>3.14149979744119667e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23616801111425101e+00</second>
+						<second>2.23600010532012394e+00</second>
 					</item>
 				</goal_state>
-				<score>1.49453310398337824e+00</score>
+				<score>9.41132498844055310e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -34151,31 +34151,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69302807013186873e+00</second>
+						<second>-1.77230653496244694e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.80084687925616693e+00</second>
+						<second>-7.33376172770565521e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12648455461922148e+00</second>
+						<second>-8.73595581161907497e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.32644525729222318e+00</second>
+						<second>-5.18625279468276856e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31287724919839022e+00</second>
+						<second>-2.62974880159214974e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.91158706424462843e-01</second>
+						<second>3.14149996087379124e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87548964152909536e+00</second>
+						<second>2.13510519039842128e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -34183,34 +34183,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73767005583987189e+00</second>
+						<second>-1.81862692041195051e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.82794106276114654e-01</second>
+						<second>-1.47327249453790360e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.29010797147696743e-01</second>
+						<second>-8.86973069373741096e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-4.96844218509007174e-01</second>
+						<second>-3.98272275704297629e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.18736103867719933e-01</second>
+						<second>-2.71869059061943164e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.71231272818485303e-01</second>
+						<second>3.04224795465348175e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.19633811398091305e+00</second>
+						<second>2.19641956548873285e+00</second>
 					</item>
 				</goal_state>
-				<score>1.63222029782648814e+00</score>
+				<score>1.03176634409754622e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -34241,31 +34241,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71200749679306385e+00</second>
+						<second>-1.88532310113736656e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.93756016865799341e-01</second>
+						<second>-1.24541321851845077e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.08769887170648949e+00</second>
+						<second>1.72554943802915317e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.47052814074743088e+00</second>
+						<second>8.99884508080742301e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.11554727429691414e-01</second>
+						<second>3.41501555547702104e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.32656297122196376e+00</second>
+						<second>-8.53359524588502144e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79949476404754072e+00</second>
+						<second>2.19777698353940520e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -34273,34 +34273,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61527761859090879e+00</second>
+						<second>-1.91966590564995143e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.32872535146387183e-01</second>
+						<second>2.57033463332335815e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.40664019055545486e+00</second>
+						<second>1.53760195366769881e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46575382306285995e+00</second>
+						<second>2.48652405494522860e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.77307290490046543e-01</second>
+						<second>2.26680421048789688e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.39456950429085946e+00</second>
+						<second>1.46683603346302815e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.05347802109407063e+00</second>
+						<second>2.05317299488582394e+00</second>
 					</item>
 				</goal_state>
-				<score>1.87907011003960323e+00</score>
+				<score>1.26991282693311891e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -34331,31 +34331,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68147037053225556e+00</second>
+						<second>-1.87790646157441721e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.68746030616156073e-02</second>
+						<second>8.16073062843705038e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.77603932187852576e+00</second>
+						<second>1.73253012695474262e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.61335247594764497e-01</second>
+						<second>-1.30659944865078148e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.39054718758122831e-01</second>
+						<second>-8.61462304007950541e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.10959211558974680e-01</second>
+						<second>2.40036025761119452e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.12704227996663553e+00</second>
+						<second>2.19857969550768972e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -34363,34 +34363,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78637060988341356e+00</second>
+						<second>-1.88470583418511084e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.04721522689026075e-01</second>
+						<second>-1.19561726598821291e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.71036451288940472e+00</second>
+						<second>1.72625271724328777e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.56763737192674513e-01</second>
+						<second>9.45783536992449991e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.13248621962688190e-01</second>
+						<second>3.99871000147813821e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.58036920870392184e-01</second>
+						<second>-7.80546268932996168e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19784145324850666e+00</second>
+						<second>2.19776768373381692e+00</second>
 					</item>
 				</goal_state>
-				<score>1.64889685136996134e+00</score>
+				<score>1.04853958678915560e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -34691,31 +34691,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73767005583987189e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.82794106276114654e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.29010797147696743e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-4.96844218509007174e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.18736103867719933e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.71231272818485303e-01</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.19633811398091305e+00</second>
+						<second>0.00000000000000000e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -34723,34 +34723,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81046877911026249e+00</second>
+						<second>-1.91354665631722276e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.66904686269479896e-01</second>
+						<second>-2.96699999995778052e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.61925678195790335e-01</second>
+						<second>-8.96393682147945237e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.55227369477201627e-01</second>
+						<second>3.10054798745581417e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.08913892870775819e-01</second>
+						<second>3.10864320689869533e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.83019048046749466e-01</second>
+						<second>-3.00111627484888466e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23355078064531121e+00</second>
+						<second>-2.23354722754471968e+00</second>
 					</item>
 				</goal_state>
-				<score>1.52146948425756112e+00</score>
+				<score>9.64923647314701038e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -34781,31 +34781,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72123762380160583e+00</second>
+						<second>-1.91956372614706150e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.94349126438407294e-01</second>
+						<second>2.27477177112056367e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.41814205261485693e+00</second>
+						<second>1.30229037924990299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.70103893831332886e+00</second>
+						<second>-2.48535133471754155e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.45500599065087943e-01</second>
+						<second>-2.37345609484678366e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.16755459668353634e+00</second>
+						<second>1.11193526582225921e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19858877380077899e+00</second>
+						<second>1.74984045300641466e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -34813,34 +34813,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74113936401921787e+00</second>
+						<second>-1.91972015317507561e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.87954735110198912e-01</second>
+						<second>-2.49438316399876250e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.27724270996238354e+00</second>
+						<second>1.53640317859988973e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.58011856423481412e+00</second>
+						<second>-2.49578089603015973e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.23467396762995785e-01</second>
+						<second>-2.27484712287693708e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.22808888305042796e+00</second>
+						<second>-1.46545904953571837e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.05201743406381443e+00</second>
+						<second>2.05185659662847453e+00</second>
 					</item>
 				</goal_state>
-				<score>1.83344902300973045e+00</score>
+				<score>1.27183276336729989e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -34871,31 +34871,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76948165787523615e+00</second>
+						<second>-1.91829455010297778e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.14446121960135117e-02</second>
+						<second>2.60730813031981090e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44840159371996102e+00</second>
+						<second>1.52469187803573059e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.55019538370574494e+00</second>
+						<second>-2.98236049922073365e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.58563804147301823e+00</second>
+						<second>-2.23970532538636358e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.82890739969862748e-01</second>
+						<second>1.31353998525664650e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.89053067811971709e+00</second>
+						<second>1.96937905443782646e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -34903,34 +34903,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76507176844913860e+00</second>
+						<second>-1.87944013049928116e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.43230634582450922e-01</second>
+						<second>9.06526503861989769e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.70219748559920148e+00</second>
+						<second>1.73163533616913501e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.75468562789537152e+00</second>
+						<second>-1.22784951672225556e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.68148189665566505e+00</second>
+						<second>-7.57090782902621745e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.08926704070259495e-01</second>
+						<second>3.66303717566818857e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.19857489548238449e+00</second>
+						<second>2.19857694380479307e+00</second>
 					</item>
 				</goal_state>
-				<score>1.64071162595965658e+00</score>
+				<score>1.04719191319964225e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -35231,31 +35231,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.81862692041195051e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.47327249453790360e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-8.86973069373741096e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-3.98272275704297629e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.71869059061943164e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>3.04224795465348175e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.19641956548873285e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -35263,34 +35263,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81878511637749329e+00</second>
+						<second>-1.91290683419656959e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.23695875169699032e-01</second>
+						<second>-3.68044152644169620e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.46439707977363764e-01</second>
+						<second>-9.30651817113451019e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.42563015188256659e-01</second>
+						<second>-5.16860664678055470e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-4.80643119460821555e-01</second>
+						<second>-2.95391746813209277e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.45171057621394994e-01</second>
+						<second>2.83650626091567881e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23337729625187453e+00</second>
+						<second>2.23341677090364632e+00</second>
 					</item>
 				</goal_state>
-				<score>1.52375655115017827e+00</score>
+				<score>9.56930090844030912e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -35321,31 +35321,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74534320147338917e+00</second>
+						<second>-1.84591038154563480e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>8.08709717487895441e-02</second>
+						<second>2.73311672330904143e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.46612675263163017e+00</second>
+						<second>1.74150946330387657e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.50477412546985612e+00</second>
+						<second>-3.51261039806369690e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56047210829203520e+00</second>
+						<second>-2.16142231766797588e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.26321566280744507e-01</second>
+						<second>1.36877994885647086e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.80325369103601685e+00</second>
+						<second>2.12633422995466015e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -35353,34 +35353,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76918515783345631e+00</second>
+						<second>-1.91959758240475664e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.16873408255978202e-02</second>
+						<second>2.63578650668459202e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.56584339162334074e+00</second>
+						<second>1.52372448481979328e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.57225136447145841e+00</second>
+						<second>-2.94849039744469243e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.61958484224720634e+00</second>
+						<second>-2.20612224811658209e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.99527848367228533e-01</second>
+						<second>1.35502990288531106e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.96939053005501497e+00</second>
+						<second>1.96930170303618102e+00</second>
 					</item>
 				</goal_state>
-				<score>2.21784973568084132e+00</score>
+				<score>1.40686456977122343e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -35411,31 +35411,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74534320147338917e+00</second>
+						<second>-1.85927848136926110e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>8.08709717487895441e-02</second>
+						<second>3.63634056874405642e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.46612675263163017e+00</second>
+						<second>1.51934021306274536e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.50477412546985612e+00</second>
+						<second>-4.49671522543681590e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56047210829203520e+00</second>
+						<second>-3.69485442371662365e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.26321566280744507e-01</second>
+						<second>2.02830256321682473e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.80325369103601685e+00</second>
+						<second>1.83807354267429246e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -35443,34 +35443,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70161036284326683e+00</second>
+						<second>-1.84549999730031233e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.07033749218828518e-03</second>
+						<second>2.72618834858430081e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.78098493310168071e+00</second>
+						<second>1.74178003573458895e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.59839466401557484e+00</second>
+						<second>-3.52255636999881605e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.63976262394450156e+00</second>
+						<second>-2.17054258441619241e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.67630116348924718e-01</second>
+						<second>1.35662581583984643e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.12629714162842287e+00</second>
+						<second>2.12629508068747830e+00</second>
 					</item>
 				</goal_state>
-				<score>1.85605535014282252e+00</score>
+				<score>1.16991719645783046e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -35501,31 +35501,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72123762380160583e+00</second>
+						<second>-1.91829455010297778e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.94349126438407294e-01</second>
+						<second>2.60730813031981090e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.41814205261485693e+00</second>
+						<second>1.52469187803573059e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.70103893831332886e+00</second>
+						<second>-2.98236049922073365e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.45500599065087943e-01</second>
+						<second>-2.23970532538636358e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.16755459668353634e+00</second>
+						<second>1.31353998525664650e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19858877380077899e+00</second>
+						<second>1.96937905443782646e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -35533,34 +35533,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.84245461901871166e+00</second>
+						<second>-1.77771756650459345e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.04194671261787009e+00</second>
+						<second>5.35775680852943692e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.47154084714350342e+00</second>
+						<second>1.91958303010308051e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.02006896370979705e+00</second>
+						<second>-2.92016938016123495e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.58064476397714693e-01</second>
+						<second>2.01295259335589755e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.97512776275998991e+00</second>
+						<second>4.17550886251173425e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.24598621125695619e+00</second>
+						<second>2.24584463402169510e+00</second>
 					</item>
 				</goal_state>
-				<score>1.46433250340691146e+00</score>
+				<score>9.52576891951840282e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -35681,31 +35681,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70973868526433348e+00</second>
+						<second>-1.91959855975022764e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.13465494141019230e+00</second>
+						<second>-1.28718996055976764e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.52541428617519270e+00</second>
+						<second>-1.53801849211403230e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.45360459800229069e+00</second>
+						<second>-3.77384210194172010e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.45343966798897828e+00</second>
+						<second>-2.90169555944808888e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.07375289197738866e+00</second>
+						<second>1.76533960843441839e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.09834208018544732e+00</second>
+						<second>2.01025235394594670e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -35713,34 +35713,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.82360175648419687e+00</second>
+						<second>-1.81421854827414930e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.80198631524536568e+00</second>
+						<second>-1.36180723575808060e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.41685676848750575e+00</second>
+						<second>-1.44646493236973073e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.88031591604325721e+00</second>
+						<second>-2.80632664546595800e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.63110363736412101e+00</second>
+						<second>-2.62446469402513793e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.80260502746759488e+00</second>
+						<second>1.76787953121605690e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23428557187584342e+00</second>
+						<second>2.23427596016691687e+00</second>
 					</item>
 				</goal_state>
-				<score>1.49885286916037175e+00</score>
+				<score>9.48378148399479926e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -35771,31 +35771,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66779302973694787e+00</second>
+						<second>-1.91979894210484048e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.67349520267496055e-01</second>
+						<second>-9.76452621080059702e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.27355493979192302e-01</second>
+						<second>-1.47267154492116870e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.09410429684214550e-01</second>
+						<second>-4.92225315923981055e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.64834058471744793e+00</second>
+						<second>-2.75560827590958723e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.87277022180285257e+00</second>
+						<second>2.08454417522218272e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.09845454624569605e+00</second>
+						<second>2.01888186416396609e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -35803,34 +35803,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85328912498311049e+00</second>
+						<second>-1.84392594343794758e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.29080996963506101e-02</second>
+						<second>-1.06870613741542608e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.79506499438766687e-01</second>
+						<second>-1.35036356874902941e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.46430607230658105e-01</second>
+						<second>-3.62701774961848633e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.82430149653353846e+00</second>
+						<second>-2.62061393140722965e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14127976856162805e+00</second>
+						<second>2.06391667680832613e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19434577502995287e+00</second>
+						<second>2.19434682050611451e+00</second>
 					</item>
 				</goal_state>
-				<score>1.65731622919481536e+00</score>
+				<score>1.02054804712604696e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -35861,31 +35861,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59862867652796581e+00</second>
+						<second>-1.74700369797287580e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.97014642801220974e-01</second>
+						<second>3.79223978530635331e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.28259836065379340e+00</second>
+						<second>1.29163933122156438e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.36408602374176446e+00</second>
+						<second>-5.61190019507690874e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.35948115356531440e+00</second>
+						<second>-5.79640947858891309e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.45425909565012812e-01</second>
+						<second>2.39339844163001719e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.22478101300033804e+00</second>
+						<second>1.42475833586186851e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -35893,34 +35893,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71670712376820056e+00</second>
+						<second>-1.81468950113224792e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.79003587336505066e-01</second>
+						<second>3.17920249851510350e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.45375954288232201e+00</second>
+						<second>1.41706010221304313e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46477275640420990e+00</second>
+						<second>-5.17728455831517831e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51932267323400350e+00</second>
+						<second>-4.76422545148714460e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.03120276869565509e-03</second>
+						<second>1.50668689505493059e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.68403153904001113e+00</second>
+						<second>1.68401477291842605e+00</second>
 					</item>
 				</goal_state>
-				<score>2.77861126005283010e+00</score>
+				<score>1.74522567438303106e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -35951,31 +35951,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74755047147047371e+00</second>
+						<second>-1.84591038154563480e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96699993615339963e+00</second>
+						<second>2.73311672330904143e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.34997560633739044e+00</second>
+						<second>1.74150946330387657e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52296230729895044e+00</second>
+						<second>-3.51261039806369690e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.55986805729571332e+00</second>
+						<second>-2.16142231766797588e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.13241144504164248e+00</second>
+						<second>1.36877994885647086e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.62079364996864350e+00</second>
+						<second>2.12633422995466015e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -35983,34 +35983,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73925868115602777e+00</second>
+						<second>-1.85927848136926110e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.95930118755284877e+00</second>
+						<second>3.63634056874405642e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.57284722306790581e+00</second>
+						<second>1.51934021306274536e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.50288142124191326e+00</second>
+						<second>-4.49671522543681590e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.58147363065314694e+00</second>
+						<second>-3.69485442371662365e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14149999579694716e+00</second>
+						<second>2.02830256321682473e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.83804557518041944e+00</second>
+						<second>1.83807354267429246e+00</second>
 					</item>
 				</goal_state>
-				<score>2.53970747685909259e+00</score>
+				<score>1.59777022248894007e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36041,31 +36041,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74534320147338917e+00</second>
+						<second>-1.91979680596846936e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>8.08709717487895441e-02</second>
+						<second>1.76228421155096127e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.46612675263163017e+00</second>
+						<second>1.42987014335291485e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.50477412546985612e+00</second>
+						<second>-3.04613837922361408e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56047210829203520e+00</second>
+						<second>-2.59736514635555193e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.26321566280744507e-01</second>
+						<second>3.85990913094435839e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.80325369103601685e+00</second>
+						<second>1.89049743268955450e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36073,34 +36073,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.62760127502048668e+00</second>
+						<second>-1.79496787518604362e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.41397017045672146e-01</second>
+						<second>4.01228691911783286e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.81154004884962960e+00</second>
+						<second>1.74403617891055895e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44709615825252147e+00</second>
+						<second>-5.16443769089195315e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.54991212224829322e+00</second>
+						<second>-3.45109384921294726e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.11878768455815824e-04</second>
+						<second>2.42383656243069429e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.99617595192988895e+00</second>
+						<second>1.99613260590260011e+00</second>
 					</item>
 				</goal_state>
-				<score>2.20858460213500596e+00</score>
+				<score>1.38777068952350091e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36131,31 +36131,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66779302973694787e+00</second>
+						<second>-1.91979822929661315e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.67349520267496055e-01</second>
+						<second>-1.78022193390661765e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.27355493979192302e-01</second>
+						<second>-1.58661654475304870e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.09410429684214550e-01</second>
+						<second>-2.62278317217379930e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.64834058471744793e+00</second>
+						<second>-3.10132490982756126e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.87277022180285257e+00</second>
+						<second>1.27961282382295982e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.09845454624569605e+00</second>
+						<second>1.95452363784615391e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36163,34 +36163,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.21457652806431060e+00</second>
+						<second>-1.91688543764048824e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.45865043020349422e-01</second>
+						<second>-2.16463313571906246e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-2.36681432456512408e-01</second>
+						<second>-1.62616265073105182e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.10736582538653439e-01</second>
+						<second>-1.83487993465973775e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.66004874558748305e+00</second>
+						<second>-3.03044247364999864e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.54258151607269056e+00</second>
+						<second>9.13015874280866724e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.10292606190553499e+00</second>
+						<second>2.10290901437566857e+00</second>
 					</item>
 				</goal_state>
-				<score>1.45078837635414915e+00</score>
+				<score>1.19882446988788763e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36221,31 +36221,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80048301098270747e+00</second>
+						<second>-1.91979822929661315e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84968805161785999e+00</second>
+						<second>-1.78022193390661765e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84748430205586645e+00</second>
+						<second>-1.58661654475304870e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.46332549145983482e-01</second>
+						<second>-2.62278317217379930e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.98662348788025467e+00</second>
+						<second>-3.10132490982756126e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.20534791554624299e+00</second>
+						<second>1.27961282382295982e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.71109707139616929e+00</second>
+						<second>1.95452363784615391e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36253,34 +36253,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80902140764373498e+00</second>
+						<second>-1.88956939094406362e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.13647809330280403e+00</second>
+						<second>-1.82187384188769319e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.82257713740364036e+00</second>
+						<second>-1.60628106887318078e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.90797684858574079e-01</second>
+						<second>-2.15814563647163837e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.69108102408746075e-01</second>
+						<second>-2.89470819717448968e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>9.91534008625388763e-01</second>
+						<second>1.25750765258727792e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14114766393780620e+00</second>
+						<second>2.14110255260634430e+00</second>
 					</item>
 				</goal_state>
-				<score>1.62385540630320691e+00</score>
+				<score>1.12336141839508546e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36311,31 +36311,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.63523041863856133e+00</second>
+						<second>-1.91979894210484048e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.24752987467881832e-01</second>
+						<second>-9.76452621080059702e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.69679628135545912e-01</second>
+						<second>-1.47267154492116870e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.32305331533912973e-01</second>
+						<second>-4.92225315923981055e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.53168909464417080e+00</second>
+						<second>-2.75560827590958723e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71944525577046559e+00</second>
+						<second>2.08454417522218272e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91977934788938476e+00</second>
+						<second>2.01888186416396609e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36343,34 +36343,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66595129956587873e+00</second>
+						<second>-1.91973973313656487e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.62268099645884040e-01</second>
+						<second>-1.39999180894415143e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.26890886087950161e-01</second>
+						<second>-1.45769048002982871e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.10833426446853456e-01</second>
+						<second>-2.24267453271482786e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.64436515517895199e+00</second>
+						<second>-2.86775093235420453e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.87543536154473545e+00</second>
+						<second>1.70645861738861315e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.09849759934938618e+00</second>
+						<second>2.09831494957631115e+00</second>
 					</item>
 				</goal_state>
-				<score>1.84856567158747032e+00</score>
+				<score>1.19707867983732508e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36401,31 +36401,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52636168054638977e+00</second>
+						<second>-1.81747884856535458e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.32329695290015437e-01</second>
+						<second>2.76024353166631597e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12358425593804667e+00</second>
+						<second>1.32449189760756947e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.34653545758875692e+00</second>
+						<second>-4.86362819958612802e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29248955419028677e+00</second>
+						<second>-4.67290349455121989e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.39835673713761055e-01</second>
+						<second>1.06697566721945275e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.36033705620898937e-01</second>
+						<second>1.62085030155729770e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36433,34 +36433,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66037125008114206e+00</second>
+						<second>-1.75278355769587879e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.63778970879877062e-01</second>
+						<second>4.02693986599749199e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.42157645016142431e+00</second>
+						<second>1.37955125297770165e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.39863131931057483e+00</second>
+						<second>-5.86549810399918492e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.44037573262350671e+00</second>
+						<second>-5.78468287609185561e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.49784648322292213e-01</second>
+						<second>2.68459430557577372e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.49548546011881012e+00</second>
+						<second>1.49546868506181063e+00</second>
 					</item>
 				</goal_state>
-				<score>3.01154923745536252e+00</score>
+				<score>1.88802882393406674e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36491,31 +36491,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59862867652796581e+00</second>
+						<second>-1.81747884856535458e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.97014642801220974e-01</second>
+						<second>2.76024353166631597e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.28259836065379340e+00</second>
+						<second>1.32449189760756947e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.36408602374176446e+00</second>
+						<second>-4.86362819958612802e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.35948115356531440e+00</second>
+						<second>-4.67290349455121989e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.45425909565012812e-01</second>
+						<second>1.06697566721945275e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.22478101300033804e+00</second>
+						<second>1.62085030155729770e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36523,34 +36523,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66071696033655192e+00</second>
+						<second>-1.76258486500422396e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.66516941556673270e-01</second>
+						<second>4.14821462767817895e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.58218807684669871e+00</second>
+						<second>1.53572826015296338e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.39207579951939486e+00</second>
+						<second>-6.07396500370711134e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.47619092661752882e+00</second>
+						<second>-5.34272850083058470e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.48411726118480192e-01</second>
+						<second>2.75803323938971667e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.66847590820878522e+00</second>
+						<second>1.66852522440812701e+00</second>
 					</item>
 				</goal_state>
-				<score>2.87850495928771144e+00</score>
+				<score>1.80951833046807786e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36581,31 +36581,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.56576966764727238e-01</second>
+						<second>-1.84591038154563480e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.30007076503686547e+00</second>
+						<second>2.73311672330904143e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.16462994665354769e+00</second>
+						<second>1.74150946330387657e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.14150000000000018e+00</second>
+						<second>-3.51261039806369690e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.36094895155904849e+00</second>
+						<second>-2.16142231766797588e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.01437123888323422e+00</second>
+						<second>1.36877994885647086e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.60004221478434805e+00</second>
+						<second>2.12633422995466015e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36613,34 +36613,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-6.41071193222215313e-02</second>
+						<second>-1.74721130266549296e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.26431816820358334e+00</second>
+						<second>5.03379180640845414e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.07342913624144876e+00</second>
+						<second>1.72780398728786855e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.14149994031591451e+00</second>
+						<second>-6.21499305018133663e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.32084791690980730e+00</second>
+						<second>-4.52389915600342751e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.11367807974205757e+00</second>
+						<second>3.74043801359050410e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.82312702532035775e+00</second>
+						<second>1.82325668728234969e+00</second>
 					</item>
 				</goal_state>
-				<score>1.84008143270806390e+00</score>
+				<score>1.65280400180768533e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36671,31 +36671,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77095701700091990e+00</second>
+						<second>-1.91010960245262007e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.28027467059074906e+00</second>
+						<second>1.33205213599818695e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75516559145398499e+00</second>
+						<second>1.63361783748009870e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.53666287599342288e+00</second>
+						<second>-4.06668624190091477e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.76021057383044832e+00</second>
+						<second>-1.96425570276558353e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.36205101850705379e+00</second>
+						<second>1.24143696124495917e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68112457478936639e+00</second>
+						<second>1.68208662932896291e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36703,34 +36703,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.80357787001626835e+00</second>
+						<second>-1.91971058108923520e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.33994788570438228e+00</second>
+						<second>1.04841479273150284e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.80030099654551479e+00</second>
+						<second>1.59505597916708153e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.62194918536618848e+00</second>
+						<second>-2.70755527342188662e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.91323955900366460e+00</second>
+						<second>-7.30069010165329130e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.47367520452623602e+00</second>
+						<second>9.56236052072913623e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91964872262181818e+00</second>
+						<second>1.91961555723866617e+00</second>
 					</item>
 				</goal_state>
-				<score>2.10798946940520171e+00</score>
+				<score>1.50781262547820760e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36761,31 +36761,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77159396684215165e+00</second>
+						<second>-1.91959855975022764e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.06866063004510403e+00</second>
+						<second>-1.28718996055976764e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84760431402057868e+00</second>
+						<second>-1.53801849211403230e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46842125570228710e+00</second>
+						<second>-3.77384210194172010e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.86178733134676078e+00</second>
+						<second>-2.90169555944808888e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13831245581663687e+00</second>
+						<second>1.76533960843441839e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68223409075481634e+00</second>
+						<second>2.01025235394594670e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36793,34 +36793,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.75448154560338709e+00</second>
+						<second>-1.91979822929661315e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.10005141276530116e+00</second>
+						<second>-1.78022193390661765e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.90726415615026190e+00</second>
+						<second>-1.58661654475304870e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.56594157008385348e+00</second>
+						<second>-2.62278317217379930e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>3.05647911197432354e+00</second>
+						<second>-3.10132490982756126e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.24145473656550420e+00</second>
+						<second>1.27961282382295982e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95457673655683672e+00</second>
+						<second>1.95452363784615391e+00</second>
 					</item>
 				</goal_state>
-				<score>2.22355893659825643e+00</score>
+				<score>1.44807773575925058e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36851,31 +36851,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66779302973694787e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.67349520267496055e-01</second>
+						<second>-1.38760210493103275e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.27355493979192302e-01</second>
+						<second>-1.59666258587359522e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.09410429684214550e-01</second>
+						<second>-3.87272960346193740e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.64834058471744793e+00</second>
+						<second>-3.09013511379292494e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.87277022180285257e+00</second>
+						<second>1.65782922603420246e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.09845454624569605e+00</second>
+						<second>1.84170789159214432e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36883,34 +36883,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.63523041863856133e+00</second>
+						<second>-1.91979732895855304e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.24752987467881832e-01</second>
+						<second>-1.52999278244622117e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.69679628135545912e-01</second>
+						<second>-1.57907463357606148e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.32305331533912973e-01</second>
+						<second>-3.13095264150731467e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.53168909464417080e+00</second>
+						<second>-3.06981523930956257e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71944525577046559e+00</second>
+						<second>1.52459940767053781e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91977934788938476e+00</second>
+						<second>1.91962271522387229e+00</second>
 					</item>
 				</goal_state>
-				<score>2.29844892183925120e+00</score>
+				<score>1.50184639529350156e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -36941,31 +36941,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60600208451001358e+00</second>
+						<second>-1.63244507052330401e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.39463584369574600e-01</second>
+						<second>6.12575709423208048e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.17379803658478998e+00</second>
+						<second>1.43203049514248937e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40402057338696062e+00</second>
+						<second>-7.82091948850927476e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.39030962328604479e+00</second>
+						<second>-7.70649471127811792e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.44474307004051034e-01</second>
+						<second>6.69275584394438683e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.20735626834291865e+00</second>
+						<second>1.07751298874340384e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -36973,34 +36973,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52071882229153910e+00</second>
+						<second>-1.59051159214954141e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.46896069697674503e-01</second>
+						<second>5.04891536553389475e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.19807437660355820e+00</second>
+						<second>1.16148067878949912e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.31018377265576191e+00</second>
+						<second>-6.49242812518182721e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.26892992180041730e+00</second>
+						<second>-7.85203466577546583e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.96174585325917594e-01</second>
+						<second>4.72433855670620684e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.50075773335430696e-01</second>
+						<second>9.50092107377918049e-01</second>
 					</item>
 				</goal_state>
-				<score>2.65006608683111011e+00</score>
+				<score>1.65654618245615753e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -37031,31 +37031,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52636168054638977e+00</second>
+						<second>-1.74700369797287580e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.32329695290015437e-01</second>
+						<second>3.79223978530635331e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12358425593804667e+00</second>
+						<second>1.29163933122156438e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.34653545758875692e+00</second>
+						<second>-5.61190019507690874e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29248955419028677e+00</second>
+						<second>-5.79640947858891309e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.39835673713761055e-01</second>
+						<second>2.39339844163001719e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.36033705620898937e-01</second>
+						<second>1.42475833586186851e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37063,34 +37063,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.58819752554857097e+00</second>
+						<second>-1.66998243199452379e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.35258474703069631e-01</second>
+						<second>4.81014282366697965e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.35645458531869978e+00</second>
+						<second>1.31438165677594387e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.33729222575486473e+00</second>
+						<second>-6.42128577878236961e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.34292146094920062e+00</second>
+						<second>-6.99035809641233463e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.21707441816662221e-01</second>
+						<second>4.14358058141086116e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.22697069073171572e+00</second>
+						<second>1.22682605222835917e+00</second>
 					</item>
 				</goal_state>
-				<score>3.06457938100477811e+00</score>
+				<score>1.91742502543316540e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -37121,31 +37121,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61581092686358518e+00</second>
+						<second>-1.68144071268726036e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.55287638504021830e+00</second>
+						<second>4.42159505343838410e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62784505968444826e+00</second>
+						<second>1.24233450733134299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-9.30812516726647665e-01</second>
+						<second>-6.05317821629667741e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.38537965705523103e+00</second>
+						<second>-6.73486639460211478e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.30283731290217619e-01</second>
+						<second>3.45480193044623796e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.18875762740648838e+00</second>
+						<second>1.22462592956511296e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37153,34 +37153,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65961197511560377e+00</second>
+						<second>-1.69622428940774062e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.69646067714778859e+00</second>
+						<second>5.06574802196409713e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.53031577900772309e+00</second>
+						<second>1.50802538221919979e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.31741967551904460e-01</second>
+						<second>-6.70518214777994115e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.45910974851273290e+00</second>
+						<second>-6.38998592444143698e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.94840481619833039e-01</second>
+						<second>4.38479715809698745e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44337029678732121e+00</second>
+						<second>1.44347978785422693e+00</second>
 					</item>
 				</goal_state>
-				<score>3.16765444436430510e+00</score>
+				<score>1.98522989793576465e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -37211,31 +37211,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61581092686358518e+00</second>
+						<second>-1.72727793820390896e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.55287638504021830e+00</second>
+						<second>6.70505647361587687e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62784505968444826e+00</second>
+						<second>1.88156204279066808e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-9.30812516726647665e-01</second>
+						<second>-6.20629081872138055e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.38537965705523103e+00</second>
+						<second>-3.21295791925764240e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.30283731290217619e-01</second>
+						<second>5.47009279691446415e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.18875762740648838e+00</second>
+						<second>1.91966541468305296e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37243,34 +37243,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.64263555776755754e+00</second>
+						<second>-1.73836751260697508e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.64667024761761915e+00</second>
+						<second>6.54244799826771861e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.72457184368441907e+00</second>
+						<second>1.65474431822302726e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.61828225781430612e-01</second>
+						<second>-6.23444462917959741e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51961732549067596e+00</second>
+						<second>-5.13404553382337592e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.60912044417067956e-01</second>
+						<second>5.76945033302778576e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.60009435741077888e+00</second>
+						<second>1.60017110655731165e+00</second>
 					</item>
 				</goal_state>
-				<score>3.05740170523157717e+00</score>
+				<score>1.91827549872175818e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -37301,31 +37301,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71002992049489233e+00</second>
+						<second>-1.91261640589789250e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.08732051146694753e+00</second>
+						<second>1.49573815236216934e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91921652080973271e+00</second>
+						<second>1.55548343954879575e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.26610703976341110e+00</second>
+						<second>-3.94506810780048789e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.74310944076803898e+00</second>
+						<second>-5.13376861951403751e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.01040111925714582e+00</second>
+						<second>-8.94253977954919899e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44941722187336164e+00</second>
+						<second>1.08028344054483472e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37333,34 +37333,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77095701700091990e+00</second>
+						<second>-1.86812605138240273e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.28027467059074906e+00</second>
+						<second>1.05483025655967100e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75516559145398499e+00</second>
+						<second>1.61514684012397836e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.53666287599342288e+00</second>
+						<second>-4.09291964997567037e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.76021057383044832e+00</second>
+						<second>-2.82436965211935231e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.36205101850705379e+00</second>
+						<second>9.59210868377699866e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68112457478936639e+00</second>
+						<second>1.68132421021649692e+00</second>
 					</item>
 				</goal_state>
-				<score>2.87498980973320117e+00</score>
+				<score>1.84127358588096202e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -37391,31 +37391,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.91978514236800102e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.34686973681685562e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.58695199979692592e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-4.63626903705729287e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-4.15040893649990861e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.30315272509313540e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.32803242913639497e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37423,34 +37423,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77159396684215165e+00</second>
+						<second>-1.91892389556179044e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.06866063004510403e+00</second>
+						<second>1.35308585976646012e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84760431402057868e+00</second>
+						<second>1.61455537379166914e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46842125570228710e+00</second>
+						<second>-3.82021713705812782e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.86178733134676078e+00</second>
+						<second>-1.92020811276331416e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13831245581663687e+00</second>
+						<second>1.26386543435584286e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68223409075481634e+00</second>
+						<second>1.68204263034551849e+00</second>
 					</item>
 				</goal_state>
-				<score>2.77506490340637679e+00</score>
+				<score>1.84114767810480751e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -37481,31 +37481,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.84582246476757161e+00</second>
+						<second>-1.91978514236800102e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.72395355011903684e+00</second>
+						<second>1.34686973681685562e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.83810554920398217e+00</second>
+						<second>1.58695199979692592e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.29344276703311700e-01</second>
+						<second>-4.63626903705729287e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.92071990593650588e+00</second>
+						<second>-4.15040893649990861e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.25010227757585413e+00</second>
+						<second>1.30315272509313540e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49968478738721411e+00</second>
+						<second>1.32803242913639497e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37513,34 +37513,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80048301098270747e+00</second>
+						<second>-1.91791125692444453e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84968805161785999e+00</second>
+						<second>1.50339384280129584e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84748430205586645e+00</second>
+						<second>1.65340757187944565e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.46332549145983482e-01</second>
+						<second>-4.19815641067419087e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.98662348788025467e+00</second>
+						<second>-1.20613332866423159e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.20534791554624299e+00</second>
+						<second>1.41194797064613065e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.71109707139616929e+00</second>
+						<second>1.71098866915082981e+00</second>
 					</item>
 				</goal_state>
-				<score>2.71467833239565692e+00</score>
+				<score>1.79561045634076905e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -37661,31 +37661,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39616319121428889e+00</second>
+						<second>-1.63244507052330401e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.06742586034521902e-01</second>
+						<second>6.12575709423208048e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.77979776655621968e-01</second>
+						<second>1.43203049514248937e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27487058200195236e+00</second>
+						<second>-7.82091948850927476e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.15251005725304756e+00</second>
+						<second>-7.70649471127811792e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70876784890270272e-01</second>
+						<second>6.69275584394438683e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.90456580514297746e-01</second>
+						<second>1.07751298874340384e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37693,34 +37693,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39776116547487450e+00</second>
+						<second>-1.42800324446010252e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.46742538136349676e-01</second>
+						<second>6.04659420142738324e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.01345139506047777e+00</second>
+						<second>9.95685305831351508e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.23123050539687284e+00</second>
+						<second>-7.38575586084589175e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.12332802065480664e+00</second>
+						<second>-9.82126852472432921e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.72487916088626458e-01</second>
+						<second>7.00701336337041902e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.26449463597276868e-01</second>
+						<second>4.26411796624626194e-01</second>
 					</item>
 				</goal_state>
-				<score>1.31147574097958652e+00</score>
+				<score>8.37020692047484860e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -37751,31 +37751,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52636168054638977e+00</second>
+						<second>-1.68144071268726036e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.32329695290015437e-01</second>
+						<second>4.42159505343838410e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12358425593804667e+00</second>
+						<second>1.24233450733134299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.34653545758875692e+00</second>
+						<second>-6.05317821629667741e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29248955419028677e+00</second>
+						<second>-6.73486639460211478e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.39835673713761055e-01</second>
+						<second>3.45480193044623796e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.36033705620898937e-01</second>
+						<second>1.22462592956511296e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37783,34 +37783,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.51230713358653635e+00</second>
+						<second>-1.57312276667165007e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.26780305342933652e-01</second>
+						<second>5.79557139537285715e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.27372521576882147e+00</second>
+						<second>1.23944881375744198e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.23502228751209220e+00</second>
+						<second>-7.40781223072527806e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.22909502854544561e+00</second>
+						<second>-8.47141997244765244e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.78640024750708859e-01</second>
+						<second>6.35084868854829399e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.50122544749484343e-01</second>
+						<second>8.49934896454880628e-01</second>
 					</item>
 				</goal_state>
-				<score>2.53630813439910208e+00</score>
+				<score>1.63738840041712713e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -37841,31 +37841,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61581092686358518e+00</second>
+						<second>-1.56437694398859461e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.55287638504021830e+00</second>
+						<second>7.10008867998870086e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62784505968444826e+00</second>
+						<second>1.40149889790750271e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-9.30812516726647665e-01</second>
+						<second>-9.69366015251636237e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.38537965705523103e+00</second>
+						<second>-9.48726482462997844e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.30283731290217619e-01</second>
+						<second>1.12400837738553983e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.18875762740648838e+00</second>
+						<second>4.78662455768909090e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37873,34 +37873,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59635108789639024e+00</second>
+						<second>-1.61480838072505817e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.60275698183901572e+00</second>
+						<second>5.75834782150406954e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.45507801800487213e+00</second>
+						<second>1.44381645995591890e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.58229141339209467e-01</second>
+						<second>-8.20212130125834493e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.33537173421226196e+00</second>
+						<second>-7.88224687051722439e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.35957391415943984e-01</second>
+						<second>6.52366628947924077e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.07746423944436520e+00</second>
+						<second>1.07744014790945219e+00</second>
 					</item>
 				</goal_state>
-				<score>3.02662676986478862e+00</score>
+				<score>1.95836896921664477e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -37931,31 +37931,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.48830764276185601e+00</second>
+						<second>-1.63244507052330401e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.48834496702776997e+00</second>
+						<second>6.12575709423208048e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.65183174912158748e+00</second>
+						<second>1.43203049514248937e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.00106371924749715e+00</second>
+						<second>-7.82091948850927476e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29731926155392241e+00</second>
+						<second>-7.70649471127811792e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.09836415129911091e+00</second>
+						<second>6.69275584394438683e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.90826130608407118e-01</second>
+						<second>1.07751298874340384e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -37963,34 +37963,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61581092686358518e+00</second>
+						<second>-1.65722166504994872e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.55287638504021830e+00</second>
+						<second>6.66205748220882743e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62784505968444826e+00</second>
+						<second>1.60110511329429084e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-9.30812516726647665e-01</second>
+						<second>-8.58069005088566317e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.38537965705523103e+00</second>
+						<second>-7.19152535442778129e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.30283731290217619e-01</second>
+						<second>7.63646992544041114e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.18875762740648838e+00</second>
+						<second>1.18882215033215854e+00</second>
 					</item>
 				</goal_state>
-				<score>3.28915446269859846e+00</score>
+				<score>2.06961017157769156e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -38021,31 +38021,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77159396684215165e+00</second>
+						<second>-1.80722623492579304e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.06866063004510403e+00</second>
+						<second>1.22064260874978370e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84760431402057868e+00</second>
+						<second>1.81378065970056790e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46842125570228710e+00</second>
+						<second>-7.24250940944768384e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.86178733134676078e+00</second>
+						<second>-3.47418895793221549e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13831245581663687e+00</second>
+						<second>1.22781581804138051e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68223409075481634e+00</second>
+						<second>1.44913774942550044e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -38053,34 +38053,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.80997196953296724e+00</second>
+						<second>-1.84459178394975121e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.13396736033743251e+00</second>
+						<second>1.08609943140995324e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62934275283419061e+00</second>
+						<second>1.58745100595908295e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.43913050759826389e+00</second>
+						<second>-6.18984881651324037e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.57578701736583193e+00</second>
+						<second>-5.41546128749344713e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.10567519364315547e+00</second>
+						<second>1.08200643783924799e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22484651217601614e+00</second>
+						<second>1.22486381748406625e+00</second>
 					</item>
 				</goal_state>
-				<score>3.17211517225196893e+00</score>
+				<score>2.09356056330823020e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -38111,31 +38111,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80048301098270747e+00</second>
+						<second>-1.66972115122439724e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84968805161785999e+00</second>
+						<second>1.37019035644148257e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84748430205586645e+00</second>
+						<second>1.57083181469832045e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.46332549145983482e-01</second>
+						<second>-4.35853647248169940e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.98662348788025467e+00</second>
+						<second>-6.53883680261061251e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.20534791554624299e+00</second>
+						<second>1.45070056751875698e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.71109707139616929e+00</second>
+						<second>8.43404534473599532e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -38143,34 +38143,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85561443089747624e+00</second>
+						<second>-1.91978514236800102e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.94924173106034626e+00</second>
+						<second>1.34686973681685562e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.68721554220585879e+00</second>
+						<second>1.58695199979692592e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.36615599819230549e-01</second>
+						<second>-4.63626903705729287e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.69542266508565564e+00</second>
+						<second>-4.15040893649990861e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.19322003540887067e+00</second>
+						<second>1.30315272509313540e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32816737869660728e+00</second>
+						<second>1.32803242913639497e+00</second>
 					</item>
 				</goal_state>
-				<score>3.25818158883596531e+00</score>
+				<score>2.09606025037272048e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -38741,31 +38741,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60544055699404176e+00</second>
+						<second>-1.63087443996577219e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.47705731410902530e+00</second>
+						<second>7.32642053730761078e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.61232943720656929e+00</second>
+						<second>1.59595235845316585e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.06088088720692664e+00</second>
+						<second>-9.94464808720517901e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29568149074095595e+00</second>
+						<second>-8.26399506822615537e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.08014742313546153e+00</second>
+						<second>1.09552046246619628e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.85891633684039248e-01</second>
+						<second>7.85889506309931929e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -38773,34 +38773,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54923670126351598e+00</second>
+						<second>-1.56448333965917152e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.49836774517795090e+00</second>
+						<second>7.10311484156113782e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.41120415184779691e+00</second>
+						<second>1.40149880756854284e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.03709302955597948e+00</second>
+						<second>-9.68746753392331295e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.18077708524601421e+00</second>
+						<second>-9.48561177572861736e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.11410159141804610e+00</second>
+						<second>1.12380258040829273e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.79005666799255658e-01</second>
+						<second>4.79025721284659922e-01</second>
 					</item>
 				</goal_state>
-				<score>1.68196193634369906e+00</score>
+				<score>1.15277585063164101e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -38831,31 +38831,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54916048664779593e+00</second>
+						<second>-1.56437694398859461e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.49844395243749950e+00</second>
+						<second>7.10008867998870086e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.41121153989575610e+00</second>
+						<second>1.40149889790750271e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.03756026607938479e+00</second>
+						<second>-9.69366015251636237e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.18068408915521417e+00</second>
+						<second>-9.48726482462997844e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.11434521775308237e+00</second>
+						<second>1.12400837738553983e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.78707166769210490e-01</second>
+						<second>4.78662455768909090e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -38863,34 +38863,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60544055699404176e+00</second>
+						<second>-1.63087443996577219e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.47705731410902530e+00</second>
+						<second>7.32642053730761078e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.61232943720656929e+00</second>
+						<second>1.59595235845316585e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.06088088720692664e+00</second>
+						<second>-9.94464808720517901e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29568149074095595e+00</second>
+						<second>-8.26399506822615537e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.08014742313546153e+00</second>
+						<second>1.09552046246619628e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.85891633684039248e-01</second>
+						<second>7.85889506309931929e-01</second>
 					</item>
 				</goal_state>
-				<score>2.47626478979971631e+00</score>
+				<score>1.74420299000635493e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -40721,31 +40721,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36135145667084156e+00</second>
+						<second>-1.64831557231393666e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.64510607928626629e-01</second>
+						<second>2.75805752612921928e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.61588372366334565e-01</second>
+						<second>-1.26218509375873889e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.45874687191908037e-01</second>
+						<second>6.79717554929587409e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.89909758592306788e-01</second>
+						<second>-2.42223985436096401e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.37088245451391244e-01</second>
+						<second>-3.04788337158437506e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.69257833395275048e-01</second>
+						<second>1.22306911270273755e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -40753,34 +40753,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36236351439997017e+00</second>
+						<second>-1.40619178154091395e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.08646752223005028e-01</second>
+						<second>2.63433208287004117e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.74590747139882252e-01</second>
+						<second>-9.55155839690737030e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.87291978619487920e-01</second>
+						<second>7.66483215159051934e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.02823731815388220e+00</second>
+						<second>-2.16788880205503709e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.69571325828563069e-01</second>
+						<second>-6.06770442416888600e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.56067885625283997e-01</second>
+						<second>4.55921744648624228e-01</second>
 					</item>
 				</goal_state>
-				<score>1.35685204215835742e+00</score>
+				<score>8.50071637990383322e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -41081,31 +41081,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36234264325357590e+00</second>
+						<second>-1.64831557231393666e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.08630571727141700e-01</second>
+						<second>2.75805752612921928e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.74558457735316463e-01</second>
+						<second>-1.26218509375873889e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.87467967159666782e-01</second>
+						<second>6.79717554929587409e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.02828768302830720e+00</second>
+						<second>-2.42223985436096401e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.69672469130647841e-01</second>
+						<second>-3.04788337158437506e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.55924194813239925e-01</second>
+						<second>1.22306911270273755e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -41113,34 +41113,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36135145667084156e+00</second>
+						<second>-1.40705504077548649e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.64510607928626629e-01</second>
+						<second>2.67809213196089102e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.61588372366334565e-01</second>
+						<second>-8.42654192466284591e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.45874687191908037e-01</second>
+						<second>7.13535725231035367e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.89909758592306788e-01</second>
+						<second>-2.21758946987112981e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.37088245451391244e-01</second>
+						<second>-4.79711735042368803e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.69257833395275048e-01</second>
+						<second>4.69185092912972890e-01</second>
 					</item>
 				</goal_state>
-				<score>1.25329798991943786e+00</score>
+				<score>7.82934123652499064e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -41171,31 +41171,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.48221010366505923e+00</second>
+						<second>-1.71079613020848686e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84128187377438579e-01</second>
+						<second>2.82103879031056382e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.44689229164636601e-01</second>
+						<second>-1.31091010038959488e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.23214195636915225e-01</second>
+						<second>6.35313702935619840e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.53766198466411108e-01</second>
+						<second>-2.50800822094248144e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.73129912304802347e-01</second>
+						<second>-1.85727001275092646e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.52569408060089073e-01</second>
+						<second>1.42477258574310017e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -41203,34 +41203,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.49132019866036036e+00</second>
+						<second>-1.56867403361653590e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.54253477600731304e-01</second>
+						<second>2.72890641613966789e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.15054332515347069e+00</second>
+						<second>-1.11999610452119214e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.87164314367234197e-01</second>
+						<second>6.99211301282614772e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.94533768256409623e-01</second>
+						<second>-2.34372393171805005e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.02819284496538832e-01</second>
+						<second>-3.79160415899864045e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.53577580936474156e-01</second>
+						<second>9.53237748235072901e-01</second>
 					</item>
 				</goal_state>
-				<score>2.56203201461366259e+00</score>
+				<score>1.60699332624841124e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -41261,31 +41261,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.66066501829163360e+00</second>
+						<second>-1.71079613020848686e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81983341164286960e+00</second>
+						<second>2.82103879031056382e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.15459929940201778e+00</second>
+						<second>-1.31091010038959488e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51672498306495340e+00</second>
+						<second>6.35313702935619840e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.46768754438344295e+00</second>
+						<second>-2.50800822094248144e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.93849379968647062e+00</second>
+						<second>-1.85727001275092646e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.21428875815116966e+00</second>
+						<second>1.42477258574310017e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -41293,34 +41293,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64899454764704778e+00</second>
+						<second>-1.64705470308204327e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.75667356055201784e+00</second>
+						<second>2.76015219874996376e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.26185027745481104e+00</second>
+						<second>-1.26283451964704652e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46335905409314870e+00</second>
+						<second>6.82397527558052053e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.42324171315149872e+00</second>
+						<second>-2.42064003762911462e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83593037018853478e+00</second>
+						<second>-3.03266838417119600e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22308800960471209e+00</second>
+						<second>1.22306101030587344e+00</second>
 					</item>
 				</goal_state>
-				<score>2.96781167421309888e+00</score>
+				<score>1.86277413882097453e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -41531,31 +41531,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.49140078977534207e+00</second>
+						<second>-1.61392621855045149e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.54327059552048318e-01</second>
+						<second>2.96700000000000008e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.15044839052523296e+00</second>
+						<second>-9.33186066916094403e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.87464035894850012e-01</second>
+						<second>6.07191686961003341e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.94615692479908353e-01</second>
+						<second>-2.48697901515150832e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.03130205520645124e-01</second>
+						<second>-5.25874804848252830e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.53261312664367200e-01</second>
+						<second>1.04781494793339247e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -41563,34 +41563,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.48221010366505923e+00</second>
+						<second>-1.53487027819103217e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84128187377438579e-01</second>
+						<second>2.84382900645600678e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.44689229164636601e-01</second>
+						<second>-9.28763568556694286e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.23214195636915225e-01</second>
+						<second>6.70847498796880992e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.53766198466411108e-01</second>
+						<second>-2.36773896748096790e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.73129912304802347e-01</second>
+						<second>-2.30161227648038674e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.52569408060089073e-01</second>
+						<second>8.52376222440394793e-01</second>
 					</item>
 				</goal_state>
-				<score>2.09136882726456896e+00</score>
+				<score>1.30960539494270306e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -41621,31 +41621,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63462043278501756e+00</second>
+						<second>-1.61392621855045149e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.92820636833935977e+00</second>
+						<second>2.96700000000000008e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.26981424305140300e-01</second>
+						<second>-9.33186066916094403e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.59603081813040903e+00</second>
+						<second>6.07191686961003341e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.52703345022131876e+00</second>
+						<second>-2.48697901515150832e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.05732533892347869e+00</second>
+						<second>-5.25874804848252830e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.04807288272560784e+00</second>
+						<second>1.04781494793339247e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -41653,34 +41653,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.66110631140187404e+00</second>
+						<second>-1.63469438704071224e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81899582271532356e+00</second>
+						<second>2.86374081108966827e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.15444144382355574e+00</second>
+						<second>-1.16547871099548850e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51833261420991583e+00</second>
+						<second>6.81807224991277216e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.46862437408077451e+00</second>
+						<second>-2.42983401325856363e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.93814903269952898e+00</second>
+						<second>-1.68808488371877924e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.21459551553429690e+00</second>
+						<second>1.21464747888233204e+00</second>
 					</item>
 				</goal_state>
-				<score>2.81168540436485559e+00</score>
+				<score>1.76367681488830946e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -41711,31 +41711,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72782590736430341e+00</second>
+						<second>-1.65972757164686424e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.78078938911414575e+00</second>
+						<second>2.82118069403581329e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.55475685350429371e+00</second>
+						<second>-1.15507967164653746e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48050623938856640e+00</second>
+						<second>6.26775202768538819e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.56036164926105014e+00</second>
+						<second>-2.46652579767631552e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.91482966344897543e+00</second>
+						<second>-2.02090770482900639e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.66894884077853378e+00</second>
+						<second>1.21443300495074680e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -41743,34 +41743,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71482009913695577e+00</second>
+						<second>-1.71079613020848686e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81459401948418853e+00</second>
+						<second>2.82103879031056382e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.30908753455160354e+00</second>
+						<second>-1.31091010038959488e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51453723303178345e+00</second>
+						<second>6.35313702935619840e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.51405946635998445e+00</second>
+						<second>-2.50800822094248144e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.95041106789084662e+00</second>
+						<second>-1.85727001275092646e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.42503712709038943e+00</second>
+						<second>1.42477258574310017e+00</second>
 					</item>
 				</goal_state>
-				<score>2.98209612723430562e+00</score>
+				<score>1.86816532033101168e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -41891,31 +41891,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.48221010366505923e+00</second>
+						<second>-1.61392621855045149e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84128187377438579e-01</second>
+						<second>2.96700000000000008e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.44689229164636601e-01</second>
+						<second>-9.33186066916094403e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.23214195636915225e-01</second>
+						<second>6.07191686961003341e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.53766198466411108e-01</second>
+						<second>-2.48697901515150832e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.73129912304802347e-01</second>
+						<second>-5.25874804848252830e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.52569408060089073e-01</second>
+						<second>1.04781494793339247e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -41923,34 +41923,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.41187604068918326e+00</second>
+						<second>-1.44569242695700351e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.05418518222664293e-01</second>
+						<second>2.92544821402662558e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>6.70885814090585564e-01</second>
+						<second>-6.63298429237071718e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.71787633061046030e-01</second>
+						<second>6.12305857303835466e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.94493670142432773e-01</second>
+						<second>-2.41932829466143495e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.19279604451532684e-01</second>
+						<second>-1.60888288400415275e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>5.74910833977436697e-01</second>
+						<second>5.74298292735413773e-01</second>
 					</item>
 				</goal_state>
-				<score>1.17856570184381404e+00</score>
+				<score>7.36284025344814685e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -41981,31 +41981,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.66066501829163360e+00</second>
+						<second>-1.45485837923141936e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81983341164286960e+00</second>
+						<second>2.89087079839049821e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.15459929940201778e+00</second>
+						<second>-6.60283752628060716e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51672498306495340e+00</second>
+						<second>5.62134448815577725e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.46768754438344295e+00</second>
+						<second>-2.44197075742415626e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.93849379968647062e+00</second>
+						<second>-1.74261231148195084e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.21428875815116966e+00</second>
+						<second>5.74875071257781589e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -42013,34 +42013,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63462043278501756e+00</second>
+						<second>-1.61392621855045149e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.92820636833935977e+00</second>
+						<second>2.96700000000000008e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.26981424305140300e-01</second>
+						<second>-9.33186066916094403e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.59603081813040903e+00</second>
+						<second>6.07191686961003341e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.52703345022131876e+00</second>
+						<second>-2.48697901515150832e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.05732533892347869e+00</second>
+						<second>-5.25874804848252830e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.04807288272560784e+00</second>
+						<second>1.04781494793339247e+00</second>
 					</item>
 				</goal_state>
-				<score>2.32029742004960582e+00</score>
+				<score>1.45542455596446463e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -42071,31 +42071,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71482009913695577e+00</second>
+						<second>-1.77815116686493502e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81459401948418853e+00</second>
+						<second>2.87671728343350264e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.30908753455160354e+00</second>
+						<second>-1.43370101909979542e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51453723303178345e+00</second>
+						<second>5.83954684841631821e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.51405946635998445e+00</second>
+						<second>-2.60717139581401325e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.95041106789084662e+00</second>
+						<second>-9.20091045913934980e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.42503712709038943e+00</second>
+						<second>1.68214978546571925e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -42103,34 +42103,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73250365272873652e+00</second>
+						<second>-1.73390417548759146e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.91910432206721770e+00</second>
+						<second>2.91687814557943614e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.14889447344846030e+00</second>
+						<second>-1.14839048176545200e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.59656881987393007e+00</second>
+						<second>5.41634336537133332e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.57787923731777013e+00</second>
+						<second>-2.58041969776918290e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.08029447672819723e+00</second>
+						<second>-6.36318153948665782e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.37499735251213950e+00</second>
+						<second>1.37504435325823637e+00</second>
 					</item>
 				</goal_state>
-				<score>2.79881841872992743e+00</score>
+				<score>1.75295820018357695e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -42161,31 +42161,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72204748035363431e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.76075294525565029e-02</second>
+						<second>3.22215607485255157e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13160171529988962e+00</second>
+						<second>1.29119479996841413e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.17130728058755351e-01</second>
+						<second>2.73497267924299459e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.83063216325978018e-01</second>
+						<second>2.45243360007955297e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20359409465491096e-01</second>
+						<second>1.63132697745417138e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49766408053323086e+00</second>
+						<second>1.80273501994564977e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -42193,34 +42193,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68907342565908980e+00</second>
+						<second>-1.81641115086587002e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-9.97554533828211437e-02</second>
+						<second>-2.71997797765203941e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.36412620592428802e+00</second>
+						<second>1.32821739491945268e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.06242753382350985e-01</second>
+						<second>4.90359367093939569e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.63658836370434657e-01</second>
+						<second>4.69573756661680553e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>8.73594592947892629e-02</second>
+						<second>-1.01762524497854556e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.62546866462347261e+00</second>
+						<second>1.62518737407227754e+00</second>
 					</item>
 				</goal_state>
-				<score>2.78049412498447568e+00</score>
+				<score>1.75574348608066727e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -42251,31 +42251,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68147037053225556e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.68746030616156073e-02</second>
+						<second>-1.75035080538460758e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.77603932187852576e+00</second>
+						<second>1.42795588243118177e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.61335247594764497e-01</second>
+						<second>3.05647721498500002e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.39054718758122831e-01</second>
+						<second>2.60795456632877676e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.10959211558974680e-01</second>
+						<second>-3.68506029823346681e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.12704227996663553e+00</second>
+						<second>1.88855792938110034e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -42283,34 +42283,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71470172889414507e+00</second>
+						<second>-1.88193652346536133e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.26526806032483197e-02</second>
+						<second>-2.89222033805306367e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.46683742590182065e+00</second>
+						<second>1.41923921836792299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.76315635410505656e-01</second>
+						<second>3.97149059180784747e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.24458336218553844e-01</second>
+						<second>3.48192191339474433e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.55751716007980795e-01</second>
+						<second>-1.30468144116547446e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79451859098775546e+00</second>
+						<second>1.79454036034393805e+00</second>
 					</item>
 				</goal_state>
-				<score>2.56678832510078925e+00</score>
+				<score>1.62266254468867999e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -42431,31 +42431,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68307443228856290e+00</second>
+						<second>-1.61392621855045149e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.49081338160675314e-01</second>
+						<second>2.96700000000000008e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.78192401413056545e-01</second>
+						<second>-9.33186066916094403e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.54301083501514413e-01</second>
+						<second>6.07191686961003341e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.75563170899557797e-01</second>
+						<second>-2.48697901515150832e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.90336589527300237e-01</second>
+						<second>-5.25874804848252830e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.23907413525957621e+00</second>
+						<second>1.04781494793339247e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -42463,34 +42463,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.50547644474688269e+00</second>
+						<second>-1.55894905759498870e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.36040674243553836e-02</second>
+						<second>2.96700000000000008e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>6.76659388612201762e-01</second>
+						<second>-6.66991581680690060e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.13671501457785706e-01</second>
+						<second>3.49548592783498091e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.05243231709268081e-01</second>
+						<second>-2.69480018426478241e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.91956745393007512e-02</second>
+						<second>-7.32025269801875322e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.55397390560515580e-01</second>
+						<second>7.55554471920434012e-01</second>
 					</item>
 				</goal_state>
-				<score>1.46775113369699239e+00</score>
+				<score>9.20779565605111538e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -42521,31 +42521,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.55905707948953820e+00</second>
+						<second>-1.54978555799608242e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>2.80750166929996592e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.66626876561165815e-01</second>
+						<second>-9.22254614079674573e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.79161999085778900e+00</second>
+						<second>6.21202542633000676e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.69447138737248126e+00</second>
+						<second>-2.39319306411282184e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.06831516715105490e+00</second>
+						<second>-2.49723623498305070e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.54790739581616799e-01</second>
+						<second>8.52671061538958996e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -42553,7 +42553,7 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74298356744245009e+00</second>
+						<second>-1.74271318290329558e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
@@ -42561,26 +42561,26 @@
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.06206470043442125e-01</second>
+						<second>-9.06485217346031602e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.84705709009621799e+00</second>
+						<second>2.94202638793064575e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.78494963219267921e+00</second>
+						<second>-2.78518890872047731e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.08647807770610738e+00</second>
+						<second>-5.53509451413984194e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.18002683311874246e+00</second>
+						<second>1.18055368757762147e+00</second>
 					</item>
 				</goal_state>
-				<score>2.40061118769434723e+00</score>
+				<score>1.50495583098406854e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -42611,31 +42611,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68307443228856290e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.49081338160675314e-01</second>
+						<second>-1.75035080538460758e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.78192401413056545e-01</second>
+						<second>1.42795588243118177e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.54301083501514413e-01</second>
+						<second>3.05647721498500002e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.75563170899557797e-01</second>
+						<second>2.60795456632877676e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.90336589527300237e-01</second>
+						<second>-3.68506029823346681e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.23907413525957621e+00</second>
+						<second>1.88855792938110034e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -42643,34 +42643,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72273755878273893e+00</second>
+						<second>-1.84844993869825758e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.67957594580419971e-02</second>
+						<second>-1.71469450910175319e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13165598875387197e+00</second>
+						<second>1.11258189425366316e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.15694880722176041e-01</second>
+						<second>2.90353217369384298e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.81843870341059000e-01</second>
+						<second>3.11345268939683839e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.19382599520391436e-01</second>
+						<second>-4.28119211247311865e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49773831735923957e+00</second>
+						<second>1.49774552787604409e+00</second>
 					</item>
 				</goal_state>
-				<score>2.66831794064073735e+00</score>
+				<score>1.69915007665332185e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -42701,31 +42701,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72204748035363431e+00</second>
+						<second>-1.90014118775710728e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.76075294525565029e-02</second>
+						<second>-3.24176289482759783e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13160171529988962e+00</second>
+						<second>1.40632113490673327e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.17130728058755351e-01</second>
+						<second>3.49256329615662831e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.83063216325978018e-01</second>
+						<second>3.06921015816006060e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20359409465491096e-01</second>
+						<second>-1.79473968540561024e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49766408053323086e+00</second>
+						<second>1.79452567452363598e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -42733,34 +42733,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75631587186465521e+00</second>
+						<second>-1.91978920972133027e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.51201036437878958e-02</second>
+						<second>-2.26224933095799829e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.33285912673882523e+00</second>
+						<second>1.29915914852896597e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.14881591151786644e-01</second>
+						<second>2.45766153099100243e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.75425460659457211e-01</second>
+						<second>2.35050254765815342e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.53304125325520657e-01</second>
+						<second>-1.11255878176859266e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.74782516131849808e+00</second>
+						<second>1.74759244921435131e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55648081361388524e+00</score>
+				<score>1.63177963140479776e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -42791,31 +42791,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75631587186465521e+00</second>
+						<second>-1.86599507389824737e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.51201036437878958e-02</second>
+						<second>-3.12022481166436993e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.33285912673882523e+00</second>
+						<second>1.72480915032231485e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.14881591151786644e-01</second>
+						<second>3.09376102889009463e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.75425460659457211e-01</second>
+						<second>1.67388674299630669e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.53304125325520657e-01</second>
+						<second>-1.88096281174045532e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.74782516131849808e+00</second>
+						<second>2.12704651922756005e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -42823,34 +42823,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76872490052123710e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.25957736005298118e-02</second>
+						<second>-1.75035080538460758e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.44629760263244767e+00</second>
+						<second>1.42795588243118177e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.92944299624998505e-01</second>
+						<second>3.05647721498500002e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.57318024282256630e-01</second>
+						<second>2.60795456632877676e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.84525772214657191e-01</second>
+						<second>-3.68506029823346681e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.88873698038749560e+00</second>
+						<second>1.88855792938110034e+00</second>
 					</item>
 				</goal_state>
-				<score>2.34946708802678073e+00</score>
+				<score>1.49955310301714717e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -42971,31 +42971,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68307443228856290e+00</second>
+						<second>-1.55894905759498870e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.49081338160675314e-01</second>
+						<second>2.96700000000000008e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.78192401413056545e-01</second>
+						<second>-6.66991581680690060e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.54301083501514413e-01</second>
+						<second>3.49548592783498091e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.75563170899557797e-01</second>
+						<second>-2.69480018426478241e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.90336589527300237e-01</second>
+						<second>-7.32025269801875322e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.23907413525957621e+00</second>
+						<second>7.55554471920434012e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43003,34 +43003,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54366507048984825e+00</second>
+						<second>1.61453804780154919e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.56105009648136617e-01</second>
+						<second>-5.74778332042633761e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>6.50071567907060555e-01</second>
+						<second>-6.58907953981500816e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.60510964856758997e-01</second>
+						<second>1.23035127886858178e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.52449647592566340e-01</second>
+						<second>-2.98573917268204791e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.84744376758726347e-01</second>
+						<second>3.12755397028339255e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.40257492939055717e-01</second>
+						<second>-8.39899102393568242e-01</second>
 					</item>
 				</goal_state>
-				<score>1.53134877606870923e+00</score>
+				<score>9.87761452889668046e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -43061,31 +43061,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72204748035363431e+00</second>
+						<second>1.61453804780154919e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.76075294525565029e-02</second>
+						<second>-5.74778332042633761e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13160171529988962e+00</second>
+						<second>-6.58907953981500816e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.17130728058755351e-01</second>
+						<second>1.23035127886858178e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.83063216325978018e-01</second>
+						<second>-2.98573917268204791e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20359409465491096e-01</second>
+						<second>3.12755397028339255e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49766408053323086e+00</second>
+						<second>-8.39899102393568242e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43093,34 +43093,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68307443228856290e+00</second>
+						<second>1.78454803113303195e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.49081338160675314e-01</second>
+						<second>-5.21986328394157748e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.78192401413056545e-01</second>
+						<second>-8.90829329591369956e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.54301083501514413e-01</second>
+						<second>1.22161102828007698e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.75563170899557797e-01</second>
+						<second>-3.00201965933721127e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.90336589527300237e-01</second>
+						<second>3.14149986404007286e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.23907413525957621e+00</second>
+						<second>-1.23890537188772010e+00</second>
 					</item>
 				</goal_state>
-				<score>2.32822155106749928e+00</score>
+				<score>1.50816221843623699e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -43151,31 +43151,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71200749679306385e+00</second>
+						<second>1.78454803113303195e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.93756016865799341e-01</second>
+						<second>-5.21986328394157748e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.08769887170648949e+00</second>
+						<second>-8.90829329591369956e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.47052814074743088e+00</second>
+						<second>1.22161102828007698e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.11554727429691414e-01</second>
+						<second>-3.00201965933721127e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.32656297122196376e+00</second>
+						<second>3.14149986404007286e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79949476404754072e+00</second>
+						<second>-1.23890537188772010e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43183,34 +43183,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61061082601743122e+00</second>
+						<second>1.89170556954632141e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.04012670950677244e-01</second>
+						<second>-5.28444508690378290e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.02455400820469422e+00</second>
+						<second>-1.09376148231677695e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.34876663796617313e+00</second>
+						<second>1.09480086944245589e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.24976402086773386e-01</second>
+						<second>-3.02683777992828107e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.56995033304208675e+00</second>
+						<second>3.14149997649151036e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.54904078177969162e+00</second>
+						<second>-1.54876980512850171e+00</second>
 					</item>
 				</goal_state>
-				<score>2.40994679511995669e+00</score>
+				<score>1.66414034076430156e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -43241,31 +43241,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71200749679306385e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.93756016865799341e-01</second>
+						<second>-1.75035080538460758e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.08769887170648949e+00</second>
+						<second>1.42795588243118177e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.47052814074743088e+00</second>
+						<second>3.05647721498500002e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.11554727429691414e-01</second>
+						<second>2.60795456632877676e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.32656297122196376e+00</second>
+						<second>-3.68506029823346681e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79949476404754072e+00</second>
+						<second>1.88855792938110034e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43273,34 +43273,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63492630806558026e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.47010694568592792e-01</second>
+						<second>3.22215607485255157e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.19845204488886914e+00</second>
+						<second>1.29119479996841413e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.38575892215449237e+00</second>
+						<second>2.73497267924299459e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.46112089806016510e-01</second>
+						<second>2.45243360007955297e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.47732519390094508e+00</second>
+						<second>1.63132697745417138e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.80307250678343878e+00</second>
+						<second>1.80273501994564977e+00</second>
 					</item>
 				</goal_state>
-				<score>2.27374709391236385e+00</score>
+				<score>1.55361496245913333e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -43331,31 +43331,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71200749679306385e+00</second>
+						<second>-1.86599507389824737e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.93756016865799341e-01</second>
+						<second>-3.12022481166436993e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.08769887170648949e+00</second>
+						<second>1.72480915032231485e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.47052814074743088e+00</second>
+						<second>3.09376102889009463e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.11554727429691414e-01</second>
+						<second>1.67388674299630669e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.32656297122196376e+00</second>
+						<second>-1.88096281174045532e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79949476404754072e+00</second>
+						<second>2.12704651922756005e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43363,34 +43363,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63628200696457493e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.96427483637602107e-01</second>
+						<second>6.79531634732756101e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.31259965161918846e+00</second>
+						<second>1.42630378192705698e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.42814817976495068e+00</second>
+						<second>3.00250711989020147e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.58158049187980576e-01</second>
+						<second>2.75140568971398658e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.41871189143841070e+00</second>
+						<second>2.15538620387363461e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95503504694060437e+00</second>
+						<second>1.95459330631150041e+00</second>
 					</item>
 				</goal_state>
-				<score>2.05942824131045654e+00</score>
+				<score>1.39517578583557483e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -43511,31 +43511,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.43038186785274624e+00</second>
+						<second>-1.76722622570197174e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.70461545050305113e-01</second>
+						<second>2.60920649552222994e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.63310172185125335e-01</second>
+						<second>8.85784057518929302e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46420374326024794e+00</second>
+						<second>-1.17457761812994402e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.38985936870169358e+00</second>
+						<second>-2.30712500166231183e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.43749152858263313e-01</second>
+						<second>1.69437050276865092e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-5.68934538816098456e-01</second>
+						<second>1.18283135766215208e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43543,34 +43543,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54759193472655876e+00</second>
+						<second>-1.61635477488875101e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.45116231934439566e-01</second>
+						<second>9.13757602985509898e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.50684910997385457e-01</second>
+						<second>6.56111111840552597e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.59924104937342770e+00</second>
+						<second>-5.61160497938234873e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.70078877816619434e+00</second>
+						<second>-1.12619713560721424e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.75011120974503220e-01</second>
+						<second>4.64243122331855357e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.38172545163201499e-01</second>
+						<second>8.38234229098134387e-01</second>
 					</item>
 				</goal_state>
-				<score>1.53164067036578322e+00</score>
+				<score>9.83442781506739666e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -43601,31 +43601,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71882310356493284e+00</second>
+						<second>-1.76722622570197174e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.10750847382868039e-02</second>
+						<second>2.60920649552222994e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12843094630742358e+00</second>
+						<second>8.85784057518929302e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52219085085021399e+00</second>
+						<second>-1.17457761812994402e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.55487998991442478e+00</second>
+						<second>-2.30712500166231183e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.11681289833377861e-01</second>
+						<second>1.69437050276865092e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.48705804397222718e+00</second>
+						<second>1.18283135766215208e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43633,34 +43633,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68508752979002829e+00</second>
+						<second>-1.79063522587085888e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.51052539899245664e-01</second>
+						<second>8.11117587165010173e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.80559462095155010e-01</second>
+						<second>8.90963184601014979e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.58928857195714812e+00</second>
+						<second>-5.09776315447774131e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.66862269533115715e+00</second>
+						<second>-8.44732286811605698e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.93348969863758358e-01</second>
+						<second>4.68440046824292397e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.24452194545073591e+00</second>
+						<second>1.24406463940210865e+00</second>
 					</item>
 				</goal_state>
-				<score>2.33383769225944615e+00</score>
+				<score>1.51090133999656567e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -43691,31 +43691,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67625567210292359e+00</second>
+						<second>-1.91956372614706150e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.61960506364601520e-01</second>
+						<second>2.27477177112056367e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.78083761912612393e-01</second>
+						<second>1.30229037924990299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.56642561142902892e+00</second>
+						<second>-2.48535133471754155e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.64997149645367847e+00</second>
+						<second>-2.37345609484678366e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.07293225787140800e-01</second>
+						<second>1.11193526582225921e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.24415705776787799e+00</second>
+						<second>1.74984045300641466e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43723,34 +43723,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75687257357049575e+00</second>
+						<second>-1.88775910970084304e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.74018203165185459e-01</second>
+						<second>4.56135610003583422e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.07026347532716670e+00</second>
+						<second>1.09154040363722538e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.57636530400940744e+00</second>
+						<second>-1.31266778439001003e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.64059533251779133e+00</second>
+						<second>-1.33019953963238458e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.84840448906571209e-01</second>
+						<second>-1.67133169806278070e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.54399232674553488e+00</second>
+						<second>1.54408481309047785e+00</second>
 					</item>
 				</goal_state>
-				<score>2.41662736443792037e+00</score>
+				<score>1.66393671042434049e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -43781,31 +43781,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73293397164146890e+00</second>
+						<second>-1.89386929721354336e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.35223478337063741e-01</second>
+						<second>8.29760627538708995e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.20206826817653245e+00</second>
+						<second>1.08784112773327002e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.52279141459599954e+00</second>
+						<second>-5.16151411380952885e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.22476014791152554e-01</second>
+						<second>-7.00551540887954932e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.27285003863470259e+00</second>
+						<second>5.19628380937716614e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95350150191251570e+00</second>
+						<second>1.54396408201816504e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43813,34 +43813,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71783948494171534e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.89521102709657874e-01</second>
+						<second>-2.59812075916126192e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.09156861825053464e+00</second>
+						<second>1.28947713792853635e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.47754319115523103e+00</second>
+						<second>-2.71965958666329166e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.03469977063958218e-01</second>
+						<second>-2.44292411344753185e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.33418826283487224e+00</second>
+						<second>-1.56059048282625068e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79943082955497746e+00</second>
+						<second>1.79917378946996198e+00</second>
 					</item>
 				</goal_state>
-				<score>2.19338564335753849e+00</score>
+				<score>1.55737552920137190e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -43871,31 +43871,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72123762380160583e+00</second>
+						<second>-1.87790646157441721e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.94349126438407294e-01</second>
+						<second>8.16073062843705038e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.41814205261485693e+00</second>
+						<second>1.73253012695474262e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.70103893831332886e+00</second>
+						<second>-1.30659944865078148e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.45500599065087943e-01</second>
+						<second>-8.61462304007950541e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.16755459668353634e+00</second>
+						<second>2.40036025761119452e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19858877380077899e+00</second>
+						<second>2.19857969550768972e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -43903,34 +43903,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73293397164146890e+00</second>
+						<second>-1.91977390507350543e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.35223478337063741e-01</second>
+						<second>-6.34316625145386476e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.20206826817653245e+00</second>
+						<second>1.42627566972801967e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.52279141459599954e+00</second>
+						<second>-3.00380404178495430e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.22476014791152554e-01</second>
+						<second>-2.75166563066459424e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.27285003863470259e+00</second>
+						<second>-2.10977596337731471e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95350150191251570e+00</second>
+						<second>1.95325654950827676e+00</second>
 					</item>
 				</goal_state>
-				<score>2.00169792413183156e+00</score>
+				<score>1.39729052209582372e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -44051,31 +44051,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59628447741179569e+00</second>
+						<second>-1.67281362640507569e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.39068567414967675e-01</second>
+						<second>2.87190364875982762e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.46831405422174144e-01</second>
+						<second>9.20019245649819739e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.47733149161698218e+00</second>
+						<second>-4.28612450678558132e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.45015025670143860e+00</second>
+						<second>-5.38439296004421863e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.30831401400581684e-02</second>
+						<second>1.48817880341790471e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.06023489016656391e+00</second>
+						<second>1.06014756900849960e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44083,34 +44083,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.50262674496885218e+00</second>
+						<second>-1.55185680163239104e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.03568203337142553e-02</second>
+						<second>1.58980296100078522e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.68391749412691860e-01</second>
+						<second>6.60302468515549079e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.53357787332133677e+00</second>
+						<second>-3.64245858382156507e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.54389155547212775e+00</second>
+						<second>-4.51821019239614485e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.03328382151066001e-02</second>
+						<second>6.26683486239334453e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-7.46004140820640371e-01</second>
+						<second>7.46055380114339250e-01</second>
 					</item>
 				</goal_state>
-				<score>1.43871664100513241e+00</score>
+				<score>9.03470194540657995e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -44141,31 +44141,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.43038186785274624e+00</second>
+						<second>-1.77256204647013504e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.70461545050305113e-01</second>
+						<second>2.78322857644781263e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.63310172185125335e-01</second>
+						<second>1.13484978531804370e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46420374326024794e+00</second>
+						<second>-4.48233294342154753e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.38985936870169358e+00</second>
+						<second>-4.88864530915443518e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.43749152858263313e-01</second>
+						<second>1.23001239151488695e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-5.68934538816098456e-01</second>
+						<second>1.38458192483561593e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44173,34 +44173,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65769986670666714e+00</second>
+						<second>-1.72852155629797810e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.57079176835463567e-02</second>
+						<second>1.36799751991480367e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.23389576094452158e-01</second>
+						<second>9.13381969335874344e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.55436218608508314e+00</second>
+						<second>-3.62790418469688458e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.57043411977661052e+00</second>
+						<second>-4.04489307426715350e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.29549508611307623e-01</second>
+						<second>8.82412136355251522e-03</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.18279752174379582e+00</second>
+						<second>1.18297445911970778e+00</second>
 					</item>
 				</goal_state>
-				<score>2.38863337935789533e+00</score>
+				<score>1.50862546794026470e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -44231,31 +44231,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74534320147338917e+00</second>
+						<second>-1.88700256219789453e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>8.08709717487895441e-02</second>
+						<second>2.88640084857520962e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.46612675263163017e+00</second>
+						<second>1.42067949733638543e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.50477412546985612e+00</second>
+						<second>-3.87068263142991587e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56047210829203520e+00</second>
+						<second>-3.37049277169207739e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.26321566280744507e-01</second>
+						<second>1.31993904475240426e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.80325369103601685e+00</second>
+						<second>1.80317881069358754e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44263,34 +44263,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73996181694739382e+00</second>
+						<second>-1.84420903033506023e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.41229827306441139e-02</second>
+						<second>1.77133606962374623e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12838484187793964e+00</second>
+						<second>1.10825863297278904e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.56236271816107708e+00</second>
+						<second>-2.96268883582265496e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.59042257284734845e+00</second>
+						<second>-3.18961945754766552e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.80263047342040933e-01</second>
+						<second>4.69494692858823393e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.48699258630051001e+00</second>
+						<second>1.48697836131085581e+00</second>
 					</item>
 				</goal_state>
-				<score>2.68234302358124976e+00</score>
+				<score>1.70012149100215587e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -44321,31 +44321,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71882310356493284e+00</second>
+						<second>-1.89386929721354336e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.10750847382868039e-02</second>
+						<second>8.29760627538708995e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12843094630742358e+00</second>
+						<second>1.08784112773327002e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52219085085021399e+00</second>
+						<second>-5.16151411380952885e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.55487998991442478e+00</second>
+						<second>-7.00551540887954932e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.11681289833377861e-01</second>
+						<second>5.19628380937716614e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.48705804397222718e+00</second>
+						<second>1.54396408201816504e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44353,34 +44353,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75665877496725464e+00</second>
+						<second>-1.91956372614706150e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.26669164784406123e-02</second>
+						<second>2.27477177112056367e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33642150371356694e+00</second>
+						<second>1.30229037924990299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52698666501872848e+00</second>
+						<second>-2.48535133471754155e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56640553681646733e+00</second>
+						<second>-2.37345609484678366e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.50381118960854632e-01</second>
+						<second>1.11193526582225921e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75005751987880021e+00</second>
+						<second>1.74984045300641466e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55544347897950264e+00</score>
+				<score>1.63076653849638098e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -44411,31 +44411,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75665877496725464e+00</second>
+						<second>-1.91956372614706150e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.26669164784406123e-02</second>
+						<second>2.27477177112056367e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33642150371356694e+00</second>
+						<second>1.30229037924990299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52698666501872848e+00</second>
+						<second>-2.48535133471754155e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56640553681646733e+00</second>
+						<second>-2.37345609484678366e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.50381118960854632e-01</second>
+						<second>1.11193526582225921e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75005751987880021e+00</second>
+						<second>1.74984045300641466e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44443,34 +44443,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76948165787523615e+00</second>
+						<second>-1.91979680596846936e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.14446121960135117e-02</second>
+						<second>1.76228421155096127e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44840159371996102e+00</second>
+						<second>1.42987014335291485e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.55019538370574494e+00</second>
+						<second>-3.04613837922361408e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.58563804147301823e+00</second>
+						<second>-2.59736514635555193e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.82890739969862748e-01</second>
+						<second>3.85990913094435839e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.89053067811971709e+00</second>
+						<second>1.89049743268955450e+00</second>
 					</item>
 				</goal_state>
-				<score>2.34645678975905270e+00</score>
+				<score>1.49748198894878032e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -44591,31 +44591,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.51577355839081807e+00</second>
+						<second>-1.58272634953971658e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.50897663084031830e-01</second>
+						<second>4.18836740795631546e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.38651057717524329e-01</second>
+						<second>9.06066935847346877e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40809050581509965e+00</second>
+						<second>-5.04251101931481926e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.33597080905572207e+00</second>
+						<second>-6.88684468902725833e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.04779696338638018e-01</second>
+						<second>2.98814134850553470e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.56760061510644544e-01</second>
+						<second>8.56610455195879972e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44623,34 +44623,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.43027994071286857e+00</second>
+						<second>-1.47131686221817315e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.69848289579390105e-01</second>
+						<second>3.33907397126013694e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.63440923843041763e-01</second>
+						<second>6.46728058553998064e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46377055921041332e+00</second>
+						<second>-4.41231436713486413e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.38966811174495897e+00</second>
+						<second>-6.46689713843455527e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.43286369108927059e-01</second>
+						<second>2.09290085324459862e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-5.69245706922036243e-01</second>
+						<second>5.68918465851008359e-01</second>
 					</item>
 				</goal_state>
-				<score>1.16304709304642206e+00</score>
+				<score>7.19206649082844568e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -44681,31 +44681,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60600208451001358e+00</second>
+						<second>-1.68935567154674970e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.39463584369574600e-01</second>
+						<second>3.83191602644644191e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.17379803658478998e+00</second>
+						<second>1.13719646103916738e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40402057338696062e+00</second>
+						<second>-5.49085382567381708e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.39030962328604479e+00</second>
+						<second>-6.28108436952469318e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.44474307004051034e-01</second>
+						<second>2.55946238185893959e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.20735626834291865e+00</second>
+						<second>1.20695818965500901e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44713,34 +44713,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59656142047337113e+00</second>
+						<second>-1.66302647432547679e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.39514682833121684e-01</second>
+						<second>2.65002027421598119e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.46863856133768556e-01</second>
+						<second>9.25399729298417850e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.47853838524477910e+00</second>
+						<second>-4.64985875733987419e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.45083227804030779e+00</second>
+						<second>-5.61381437370012115e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.30462161183324805e-02</second>
+						<second>1.28123988316595355e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.06053724429335827e+00</second>
+						<second>1.06041138629980480e+00</second>
 					</item>
 				</goal_state>
-				<score>2.34654858074884176e+00</score>
+				<score>1.46777117363811327e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -44771,31 +44771,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52636168054638977e+00</second>
+						<second>-1.68144071268726036e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.32329695290015437e-01</second>
+						<second>4.42159505343838410e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12358425593804667e+00</second>
+						<second>1.24233450733134299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.34653545758875692e+00</second>
+						<second>-6.05317821629667741e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29248955419028677e+00</second>
+						<second>-6.73486639460211478e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.39835673713761055e-01</second>
+						<second>3.45480193044623796e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.36033705620898937e-01</second>
+						<second>1.22462592956511296e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44803,34 +44803,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68245433046076243e+00</second>
+						<second>-1.76254247030687083e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.39685215586301870e-01</second>
+						<second>2.60355282275758548e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.16545867677408244e+00</second>
+						<second>1.13997474771742824e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.48729880499814282e+00</second>
+						<second>-4.76058495495067957e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.49498154139916206e+00</second>
+						<second>-5.09348147809248086e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.51394799796670412e-02</second>
+						<second>1.02414317241327268e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.38459148676464117e+00</second>
+						<second>1.38459428232990667e+00</second>
 					</item>
 				</goal_state>
-				<score>2.78959042552129732e+00</score>
+				<score>1.75189464774009984e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -44861,31 +44861,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73640932235893741e+00</second>
+						<second>-1.68144071268726036e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96310799106575162e+00</second>
+						<second>4.42159505343838410e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.57358260983191656e+00</second>
+						<second>1.24233450733134299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.49928128043647169e+00</second>
+						<second>-6.05317821629667741e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.57746392793297119e+00</second>
+						<second>-6.73486639460211478e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.13778823383798322e+00</second>
+						<second>3.45480193044623796e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.83803655257394549e+00</second>
+						<second>1.22462592956511296e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44893,34 +44893,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74755047147047371e+00</second>
+						<second>-1.81760528477582772e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96699993615339963e+00</second>
+						<second>2.76177596583099039e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.34997560633739044e+00</second>
+						<second>1.32442347546017336e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52296230729895044e+00</second>
+						<second>-4.86081654668456431e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.55986805729571332e+00</second>
+						<second>-4.67095485167669078e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.13241144504164248e+00</second>
+						<second>1.06900764376276700e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.62079364996864350e+00</second>
+						<second>1.62083999141562618e+00</second>
 					</item>
 				</goal_state>
-				<score>2.80047577822184390e+00</score>
+				<score>1.75805592642966135e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -44951,31 +44951,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65169135203729156e+00</second>
+						<second>-1.85927848136926110e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.34043144742288489e-01</second>
+						<second>3.63634056874405642e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33243071584949258e+00</second>
+						<second>1.51934021306274536e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40410858097137936e+00</second>
+						<second>-4.49671522543681590e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.42900590092028512e+00</second>
+						<second>-3.69485442371662365e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.13023032567416651e-01</second>
+						<second>2.02830256321682473e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.42475085768363119e+00</second>
+						<second>1.83807354267429246e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -44983,34 +44983,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75701298430972952e+00</second>
+						<second>-1.88700256219789453e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>9.54678539074194227e-02</second>
+						<second>2.88640084857520962e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.46461720385084382e+00</second>
+						<second>1.42067949733638543e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52031470519337253e+00</second>
+						<second>-3.87068263142991587e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.57745974254490706e+00</second>
+						<second>-3.37049277169207739e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.09980858886173871e-01</second>
+						<second>1.31993904475240426e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.80319073181275225e+00</second>
+						<second>1.80317881069358754e+00</second>
 					</item>
 				</goal_state>
-				<score>2.56019609083287181e+00</score>
+				<score>1.61272385644519817e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -45221,31 +45221,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60600208451001358e+00</second>
+						<second>-1.68144071268726036e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.39463584369574600e-01</second>
+						<second>4.42159505343838410e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.17379803658478998e+00</second>
+						<second>1.24233450733134299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40402057338696062e+00</second>
+						<second>-6.05317821629667741e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.39030962328604479e+00</second>
+						<second>-6.73486639460211478e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.44474307004051034e-01</second>
+						<second>3.45480193044623796e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.20735626834291865e+00</second>
+						<second>1.22462592956511296e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -45253,34 +45253,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.51578471244146229e+00</second>
+						<second>-1.57265348689425588e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.50827821335512902e-01</second>
+						<second>3.89943247831179896e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.38648496269702037e-01</second>
+						<second>9.12968692485470079e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40820781547454565e+00</second>
+						<second>-5.44021473888455120e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.33598763602412918e+00</second>
+						<second>-7.08359724440802418e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.04716453103490154e-01</second>
+						<second>2.81130376598467790e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.56825038621876978e-01</second>
+						<second>8.57037486612133859e-01</second>
 					</item>
 				</goal_state>
-				<score>2.10268435612636839e+00</score>
+				<score>1.30780890766773461e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -45311,31 +45311,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.38808302703632291e+00</second>
+						<second>-1.68144071268726036e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.70627840960793653e-01</second>
+						<second>4.42159505343838410e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.56780033697572607e-01</second>
+						<second>1.24233450733134299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.31829574679541750e+00</second>
+						<second>-6.05317821629667741e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.18728380610188200e+00</second>
+						<second>-6.73486639460211478e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.59652158201288075e-01</second>
+						<second>3.45480193044623796e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.72958968718864114e-01</second>
+						<second>1.22462592956511296e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -45343,34 +45343,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60808923484551203e+00</second>
+						<second>-1.68734551745904127e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.43071565420679786e-01</second>
+						<second>3.79712264969895796e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.17316384894975800e+00</second>
+						<second>1.13844284295949150e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40748333852928553e+00</second>
+						<second>-5.54390202500135820e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.39307381626309734e+00</second>
+						<second>-6.31218500934177640e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.47518176769691700e-01</second>
+						<second>2.52745879360069259e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.20701195854197163e+00</second>
+						<second>1.20698540099265328e+00</second>
 					</item>
 				</goal_state>
-				<score>2.80918233002668227e+00</score>
+				<score>1.75663788285553846e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -45401,31 +45401,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52636168054638977e+00</second>
+						<second>-1.68144071268726036e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.32329695290015437e-01</second>
+						<second>4.42159505343838410e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12358425593804667e+00</second>
+						<second>1.24233450733134299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.34653545758875692e+00</second>
+						<second>-6.05317821629667741e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29248955419028677e+00</second>
+						<second>-6.73486639460211478e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.39835673713761055e-01</second>
+						<second>3.45480193044623796e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.36033705620898937e-01</second>
+						<second>1.22462592956511296e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -45433,34 +45433,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65828330262403600e+00</second>
+						<second>-1.74716141421878479e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.43323968110666200e-01</second>
+						<second>3.79564293216786475e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33046097279198072e+00</second>
+						<second>1.29154532739738959e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.41489316333589032e+00</second>
+						<second>-5.60938511798637296e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.43756833024471931e+00</second>
+						<second>-5.79392407136819387e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.20414621733159047e-01</second>
+						<second>2.39606609472433424e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.42484431312253901e+00</second>
+						<second>1.42471751191864304e+00</second>
 					</item>
 				</goal_state>
-				<score>2.97788731239417803e+00</score>
+				<score>1.86608348055882001e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -45761,31 +45761,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39616319121428889e+00</second>
+						<second>-1.43162078491484945e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.06742586034521902e-01</second>
+						<second>5.69292987825005481e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.77979776655621968e-01</second>
+						<second>9.57645006649043617e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27487058200195236e+00</second>
+						<second>-6.85193749834135168e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.15251005725304756e+00</second>
+						<second>-9.42540912017759691e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70876784890270272e-01</second>
+						<second>6.07355198316499534e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.90456580514297746e-01</second>
+						<second>4.90525927256854788e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -45793,34 +45793,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.38711003965367063e+00</second>
+						<second>-1.42047321809103000e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.66330375210136339e-01</second>
+						<second>5.25030144650230568e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.57217866717956190e-01</second>
+						<second>8.38831995904263605e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.31342423122981833e+00</second>
+						<second>-6.43447755516831310e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.18590408629651511e+00</second>
+						<second>-9.04448898693691050e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.58627602710992899e-01</second>
+						<second>4.95964617651202755e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.73068117441268865e-01</second>
+						<second>4.73041848986318958e-01</second>
 					</item>
 				</goal_state>
-				<score>1.26510833321260363e+00</score>
+				<score>7.88725376518611132e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -45851,31 +45851,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39616319121428889e+00</second>
+						<second>-1.68144071268726036e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.06742586034521902e-01</second>
+						<second>4.42159505343838410e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.77979776655621968e-01</second>
+						<second>1.24233450733134299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27487058200195236e+00</second>
+						<second>-6.05317821629667741e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.15251005725304756e+00</second>
+						<second>-6.73486639460211478e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70876784890270272e-01</second>
+						<second>3.45480193044623796e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.90456580514297746e-01</second>
+						<second>1.22462592956511296e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -45883,34 +45883,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52413979837612534e+00</second>
+						<second>-1.58924601094456808e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.28152527918693759e-01</second>
+						<second>4.75427815559970823e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12452626419333401e+00</second>
+						<second>1.09100533015140710e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.34116611895166127e+00</second>
+						<second>-6.21697750647229097e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.28991850224467264e+00</second>
+						<second>-7.64042999294609837e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.38119975227272440e-01</second>
+						<second>4.13103817972485521e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.36118128040124842e-01</second>
+						<second>9.36008811218751346e-01</second>
 					</item>
 				</goal_state>
-				<score>2.52323493338123273e+00</score>
+				<score>1.57430232897300265e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -45941,31 +45941,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39616319121428889e+00</second>
+						<second>-1.74700369797287580e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.06742586034521902e-01</second>
+						<second>3.79223978530635331e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.77979776655621968e-01</second>
+						<second>1.29163933122156438e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27487058200195236e+00</second>
+						<second>-5.61190019507690874e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.15251005725304756e+00</second>
+						<second>-5.79640947858891309e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70876784890270272e-01</second>
+						<second>2.39339844163001719e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.90456580514297746e-01</second>
+						<second>1.42475833586186851e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -45973,34 +45973,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59810989599078579e+00</second>
+						<second>-1.68144071268726036e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96473804212760261e-01</second>
+						<second>4.42159505343838410e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.28282700582325404e+00</second>
+						<second>1.24233450733134299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.36326996285087398e+00</second>
+						<second>-6.05317821629667741e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.35904914937748966e+00</second>
+						<second>-6.73486639460211478e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.45176015426882166e-01</second>
+						<second>3.45480193044623796e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.22484571923982077e+00</second>
+						<second>1.22462592956511296e+00</second>
 					</item>
 				</goal_state>
-				<score>2.96501439914651321e+00</score>
+				<score>1.85809010538960651e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -46391,31 +46391,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59862867652796581e+00</second>
+						<second>-1.57608715894758178e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.97014642801220974e-01</second>
+						<second>5.87637528560786326e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.28259836065379340e+00</second>
+						<second>1.23736448594295134e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.36408602374176446e+00</second>
+						<second>-7.31877952016751987e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.35948115356531440e+00</second>
+						<second>-8.43815345331954347e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.45425909565012812e-01</second>
+						<second>6.38377604956767541e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.22478101300033804e+00</second>
+						<second>8.49928036143303811e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -46423,34 +46423,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39616319121428889e+00</second>
+						<second>-1.43162078491484945e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.06742586034521902e-01</second>
+						<second>5.69292987825005481e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.77979776655621968e-01</second>
+						<second>9.57645006649043617e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27487058200195236e+00</second>
+						<second>-6.85193749834135168e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.15251005725304756e+00</second>
+						<second>-9.42540912017759691e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70876784890270272e-01</second>
+						<second>6.07355198316499534e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.90456580514297746e-01</second>
+						<second>4.90525927256854788e-01</second>
 					</item>
 				</goal_state>
-				<score>1.45552548363033196e+00</score>
+				<score>9.10126581751884156e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -48915,31 +48915,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81285670128973808e+00</second>
+						<second>-1.75898434222349120e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.12697259168847008e+00</second>
+						<second>-9.02181748462884237e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62395732420834604e+00</second>
+						<second>1.67888200187009162e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.43986013177225614e+00</second>
+						<second>8.15671444567647730e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.57072429698229943e+00</second>
+						<second>6.09617182952577052e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.09576922517238629e+00</second>
+						<second>-9.87758593309020827e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.20888429590384461e+00</second>
+						<second>1.20884613498187687e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -48947,34 +48947,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.50552021305558448e+00</second>
+						<second>-1.48550636063145602e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.17176095839038741e+00</second>
+						<second>-8.57325974849173167e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.39162742489165248e+00</second>
+						<second>1.41344588603743015e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.52576123288789756e+00</second>
+						<second>7.28121702405696070e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.24878824032758207e+00</second>
+						<second>9.09873135668698318e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.96807764466960822e+00</second>
+						<second>-1.14830445015548910e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>5.09141426093715488e-01</second>
+						<second>5.09147957316665067e-01</second>
 					</item>
 				</goal_state>
-				<score>1.76394054728272964e+00</score>
+				<score>1.20531964250234588e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49005,31 +49005,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.80543311468609735e+00</second>
+						<second>-1.89648468844720419e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.05394518815942773e+00</second>
+						<second>-1.28240364971678300e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75272151513511765e+00</second>
+						<second>1.63311863227613752e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.38947657219905762e+00</second>
+						<second>5.45450328001642615e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.66399234032112409e+00</second>
+						<second>4.28615433619086772e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.00827696029826619e+00</second>
+						<second>-1.25806031189375478e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32182745107173005e+00</second>
+						<second>1.32194818522629132e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49037,34 +49037,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.60219261547086367e+00</second>
+						<second>-1.64876767855569395e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.12487576024713887e+00</second>
+						<second>-1.21577628295976714e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.55274491891846478e+00</second>
+						<second>1.48451934672912866e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48808338672783913e+00</second>
+						<second>4.53653772799780142e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.38780958090104489e+00</second>
+						<second>7.20287473515345167e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.93296113411537474e+00</second>
+						<second>-1.28360544397899456e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.88411049228595506e-01</second>
+						<second>7.88660056112616914e-01</second>
 					</item>
 				</goal_state>
-				<score>2.58505411645056826e+00</score>
+				<score>1.73882388294874068e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49095,31 +49095,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.89438833274384355e+00</second>
+						<second>-1.91978252683742800e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.03565771589190492e+00</second>
+						<second>-1.44028423254754889e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.20601329656198031e+00</second>
+						<second>1.65639506953282445e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.19261550976849828e-01</second>
+						<second>4.85737992964276111e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.54856362719684393e-01</second>
+						<second>2.98587233686228193e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.29875650696825962e-01</second>
+						<second>-1.38851267242427379e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.42764828919268272e-01</second>
+						<second>1.46458532290340715e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49127,34 +49127,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70180119824979714e+00</second>
+						<second>-1.66835716443062032e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.61208933347308236e+00</second>
+						<second>-1.37771786953656128e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.46789399067866877e+00</second>
+						<second>1.56493242865045734e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.78573417810699631e-01</second>
+						<second>4.18218796528324388e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.38729469789955151e-01</second>
+						<second>6.46012848308030629e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.55641411698714749e+00</second>
+						<second>-1.44689227627763883e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.58804363550193961e-01</second>
+						<second>8.59037516693601066e-01</second>
 					</item>
 				</goal_state>
-				<score>2.86537122691224111e+00</score>
+				<score>1.84907103234848103e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49185,31 +49185,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.89438833274384355e+00</second>
+						<second>-1.91815918850404499e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.03565771589190492e+00</second>
+						<second>-2.41398288657026061e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.20601329656198031e+00</second>
+						<second>1.32372451360827403e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.19261550976849828e-01</second>
+						<second>-3.84897888836304380e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.54856362719684393e-01</second>
+						<second>6.35843678080842523e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.29875650696825962e-01</second>
+						<second>4.33657712086622904e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.42764828919268272e-01</second>
+						<second>1.02743738492647996e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49217,34 +49217,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73460503512780018e+00</second>
+						<second>-1.71931491354816512e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.28448050793543178e+00</second>
+						<second>-2.45673557015039279e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.47679066904701273e+00</second>
+						<second>1.44352348097883598e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.90867035649140537e-01</second>
+						<second>-3.65385059148767122e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.74561620978228560e-01</second>
+						<second>8.09038004336919081e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.52996780009756805e-01</second>
+						<second>5.99234078544248372e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.00617945325530367e-01</second>
+						<second>6.00559908424762701e-01</second>
 					</item>
 				</goal_state>
-				<score>2.05977624675478443e+00</score>
+				<score>1.45183382430241731e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49275,31 +49275,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85490735972754139e+00</second>
+						<second>-1.67760451438264013e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.85755453350982225e+00</second>
+						<second>-8.63980278887908071e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.66141532481036602e+00</second>
+						<second>1.55818641248161938e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50891182085985509e+00</second>
+						<second>8.64459164680135506e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.59843576502383611e+00</second>
+						<second>7.93663232076335934e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.14577890144303929e+00</second>
+						<second>-1.13084153831213952e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.06251881508530110e+00</second>
+						<second>7.81744224975808089e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49307,34 +49307,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.83360884213563291e+00</second>
+						<second>-1.82071524295609821e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.92958175926217423e+00</second>
+						<second>-1.17133520791414081e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.56922605030601625e+00</second>
+						<second>1.58671260971700745e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.54053993085076923e+00</second>
+						<second>6.44679715106950324e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.50630410683652505e+00</second>
+						<second>6.42023042292822810e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.17175106818797792e+00</second>
+						<second>9.88962308619349528e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.42909495308566714e-01</second>
+						<second>9.43350516746099044e-01</second>
 					</item>
 				</goal_state>
-				<score>2.73833264850141678e+00</score>
+				<score>1.94158431618014826e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49365,31 +49365,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61769388841950512e+00</second>
+						<second>-1.64646806859902961e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.38848308169308821e+00</second>
+						<second>-1.27758389249956350e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91602565380586687e+00</second>
+						<second>1.60528396544526619e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.09383642848697082e+00</second>
+						<second>5.18815544643985382e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.53563760309345865e+00</second>
+						<second>6.56061395328968788e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.15840472683926254e+00</second>
+						<second>-1.40359833624412622e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32188649050487128e+00</second>
+						<second>8.58963852465529976e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49397,34 +49397,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.88566865222674851e+00</second>
+						<second>-1.91979968470895024e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.37577388121325095e+00</second>
+						<second>-1.49964250960235845e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.61480352082282730e+00</second>
+						<second>1.54994287566443889e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.32038987290790799e-01</second>
+						<second>3.90855829114082121e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.31608048721753712e-01</second>
+						<second>5.23127033081822623e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>9.48037229724794317e-01</second>
+						<second>8.75615975044806927e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.06263268088547380e+00</second>
+						<second>1.06231214406949270e+00</second>
 					</item>
 				</goal_state>
-				<score>2.97853579320359563e+00</score>
+				<score>2.04360541937839341e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49455,31 +49455,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70916885857598388e+00</second>
+						<second>-1.85585545833598120e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.80872433337070659e+00</second>
+						<second>-1.38566797755045656e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.38775863373580544e+00</second>
+						<second>1.76524508493471166e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.30205970064226544e-02</second>
+						<second>5.53675521165260975e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.50159876650583168e-01</second>
+						<second>1.36012956857808037e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.65171257776160441e+00</second>
+						<second>-1.29171456448491484e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.58698288929702569e-01</second>
+						<second>1.70864166684574248e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49487,34 +49487,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979999999999995e+00</second>
+						<second>-1.91815918850404499e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.40538538113626199e+00</second>
+						<second>-2.41398288657026061e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.32628472886373538e+00</second>
+						<second>1.32372451360827403e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.75872425370206986e-01</second>
+						<second>-3.84897888836304380e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.32702448192824285e-01</second>
+						<second>6.35843678080842523e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.38228833737893286e-01</second>
+						<second>4.33657712086622904e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.02767833755982729e+00</second>
+						<second>1.02743738492647996e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88357235575551707e+00</score>
+				<score>2.02691312715322647e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49545,31 +49545,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.88858173533046636e+00</second>
+						<second>-1.88857675815795378e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.85011296713659235e+00</second>
+						<second>2.85010062023220012e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62141289014037171e+00</second>
+						<second>1.62141428709623381e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.05165358780430518e+00</second>
+						<second>-1.08995223809811592e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31608853617363986e+00</second>
+						<second>8.25508737730694331e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.46275893871038697e-02</second>
+						<second>1.46249087562678355e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-7.94857136755156790e-01</second>
+						<second>7.94857066565525683e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49577,34 +49577,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73845365113803330e+00</second>
+						<second>-1.73844938937412530e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.90633937476718662e+00</second>
+						<second>2.90632667505811115e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.51213740750317660e+00</second>
+						<second>1.51213836322433570e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.03803551979915598e+00</second>
+						<second>-1.10356972870278591e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.20958329212663074e+00</second>
+						<second>9.32013347710474505e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20861037790856335e-01</second>
+						<second>2.20858868876736003e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-6.89434430445925783e-01</second>
+						<second>6.89434420997429354e-01</second>
 					</item>
 				</goal_state>
-				<score>2.34282407268101167e+00</score>
+				<score>1.59513784484477728e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49635,31 +49635,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.78806346143353867e+00</second>
+						<second>-1.91128413571698852e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.04455237902934917e+00</second>
+						<second>-1.58941703890717090e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.82930748460479142e+00</second>
+						<second>1.60143037433179036e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48374742953864791e+00</second>
+						<second>3.35434180887394628e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.86426652995970032e+00</second>
+						<second>-7.96827284117425788e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11474088779904079e+00</second>
+						<second>-1.49564470006934025e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.67060792421692006e+00</second>
+						<second>1.92775721880974182e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49667,34 +49667,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77197846047015695e+00</second>
+						<second>-1.91970159469533574e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.98618328749709638e+00</second>
+						<second>-1.43902224099983966e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.86111341630326832e+00</second>
+						<second>1.65728620356050804e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.35719930029162228e+00</second>
+						<second>4.87217547095838477e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.78484133738746875e+00</second>
+						<second>2.99037064826287835e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.96056658700258901e+00</second>
+						<second>-1.38730862671138566e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.46472789326928021e+00</second>
+						<second>1.46406969247675844e+00</second>
 					</item>
 				</goal_state>
-				<score>3.15583035082615115e+00</score>
+				<score>2.03002597890647007e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49725,31 +49725,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76432032113259485e+00</second>
+						<second>1.84016620003968745e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.87785049076220245e+00</second>
+						<second>3.33659334539958344e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.23704501601275485e-01</second>
+						<second>-1.15172648805202638e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.54266727284059657e-01</second>
+						<second>2.41806161390585039e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.69774067705066001e-01</second>
+						<second>-2.45691762540465142e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.73707676792904664e+00</second>
+						<second>3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.83969489732625302e+00</second>
+						<second>1.64533671203304799e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49757,34 +49757,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73641135044809714e+00</second>
+						<second>1.66683223673640479e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96700000000000008e+00</second>
+						<second>3.62568299023152199e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.01876742803950848e+00</second>
+						<second>-1.01106825810533962e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.97535129607718418e-01</second>
+						<second>2.15608202340869237e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.87750280483348497e-01</second>
+						<second>-2.26733276903885361e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.12362803879805873e-02</second>
+						<second>3.14149998346157711e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.48870294390675073e+00</second>
+						<second>1.48861253901865154e+00</second>
 					</item>
 				</goal_state>
-				<score>3.13203726682918937e+00</score>
+				<score>2.00131505333781295e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49815,31 +49815,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.83693070389912227e+00</second>
+						<second>-1.89224372143655883e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.82927561456175836e+00</second>
+						<second>2.92419348544080515e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.46863845655415437e+00</second>
+						<second>1.45379735976819657e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.13583353493909334e+00</second>
+						<second>-9.12021362349807130e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31602270875400817e+00</second>
+						<second>7.69580921312952748e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.50312110900653939e-01</second>
+						<second>-1.09586556999951928e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.26240530216323976e+00</second>
+						<second>1.26211855936764339e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49847,34 +49847,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.77730466495425832e+00</second>
+						<second>-1.77753845939385502e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96693061005466019e+00</second>
+						<second>2.96699961481169083e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.35301256598507447e+00</second>
+						<second>1.35308938358546738e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.02883438955599127e+00</second>
+						<second>-1.11230730774814623e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.23154570961572851e+00</second>
+						<second>9.09923396634078174e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-6.56557792585911321e-02</second>
+						<second>-6.57703657120262408e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.11737135502758700e+00</second>
+						<second>1.11743511001640572e+00</second>
 					</item>
 				</goal_state>
-				<score>2.95305310401394205e+00</score>
+				<score>2.07176141101794026e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49905,31 +49905,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73643636432677173e+00</second>
+						<second>-1.77753845939385502e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96700000000000008e+00</second>
+						<second>2.96699961481169083e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.01878274703353910e+00</second>
+						<second>1.35308938358546738e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.97534025482065623e-01</second>
+						<second>-1.11230730774814623e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.87750756914439298e-01</second>
+						<second>9.09923396634078174e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.12586922386320393e-02</second>
+						<second>-6.57703657120262408e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.48868350544926020e+00</second>
+						<second>1.11743511001640572e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -49937,34 +49937,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85990884450483729e+00</second>
+						<second>-1.88857675815795378e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.78024657962338528e+00</second>
+						<second>2.85010062023220012e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.63022584083147914e+00</second>
+						<second>1.62141428709623381e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.97783691842723419e+00</second>
+						<second>-1.08995223809811592e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.51339575830519335e-01</second>
+						<second>8.25508737730694331e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14128574723019183e+00</second>
+						<second>1.46249087562678355e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.94595558628390597e-01</second>
+						<second>7.94857066565525683e-01</second>
 					</item>
 				</goal_state>
-				<score>2.66375859496048450e+00</score>
+				<score>1.69196400925705398e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -49995,31 +49995,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67973706589754679e+00</second>
+						<second>-1.90452249286867903e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.80247613652238581e+00</second>
+						<second>-1.70587212515639175e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.48308855035187159e-01</second>
+						<second>1.50074398715173363e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.02210678060741422e-01</second>
+						<second>2.63818937548294385e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.53157556082115343e-01</second>
+						<second>-2.89383879907489316e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.53680153762953209e+00</second>
+						<second>-1.65285380444310848e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70868304885012123e+00</second>
+						<second>2.10509473855476736e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50027,34 +50027,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76069363412145230e+00</second>
+						<second>-1.91979844420357604e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.88632891581004491e+00</second>
+						<second>-1.75433001574751768e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.22397329219062478e-01</second>
+						<second>1.59662612117725322e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.58825529712683711e-01</second>
+						<second>3.86701456655521136e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.75943265251787517e-01</second>
+						<second>-4.95563743086409741e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.74186901960491936e+00</second>
+						<second>-1.65833231975519024e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.83969490136012603e+00</second>
+						<second>1.83958164240917910e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55182926906895702e+00</score>
+				<score>1.62055500238982214e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50085,31 +50085,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67973706589754679e+00</second>
+						<second>-1.77230653496244694e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.80247613652238581e+00</second>
+						<second>-7.33376172770565521e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.48308855035187159e-01</second>
+						<second>-8.73595581161907497e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.02210678060741422e-01</second>
+						<second>-5.18625279468276856e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.53157556082115343e-01</second>
+						<second>-2.62974880159214974e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.53680153762953209e+00</second>
+						<second>3.14149996087379124e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70868304885012123e+00</second>
+						<second>2.13510519039842128e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50117,34 +50117,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.90671296418576874e+00</second>
+						<second>1.84016620003968745e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96700000000000008e+00</second>
+						<second>3.33659334539958344e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.16128655495151434e+00</second>
+						<second>-1.15172648805202638e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.12770901099065957e-01</second>
+						<second>2.41806161390585039e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.84661409444183433e-01</second>
+						<second>-2.45691762540465142e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>8.82583026095726253e-02</second>
+						<second>3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.64534115479500231e+00</second>
+						<second>1.64533671203304799e+00</second>
 					</item>
 				</goal_state>
-				<score>2.89508797070991886e+00</score>
+				<score>1.90415311914916174e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50175,31 +50175,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91969890351458461e+00</second>
+						<second>1.91977003543116287e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96320782660357018e+00</second>
+						<second>-1.78254038665974585e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37175494457080327e+00</second>
+						<second>-1.37173676789760401e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.39425974887273663e+00</second>
+						<second>2.39438024017032269e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.50759068322008760e+00</second>
+						<second>-2.50768358416143178e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13136781864708441e-01</second>
+						<second>2.92843535013849987e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.55297671528658121e+00</second>
+						<second>1.55297723773787522e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50207,34 +50207,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91559279722673237e+00</second>
+						<second>1.91979962287215056e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>-1.66575616251079250e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44877935491392051e+00</second>
+						<second>-1.44791500704787235e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27267919981740985e+00</second>
+						<second>2.28079919551900945e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.39744767907745171e+00</second>
+						<second>-2.40220583402714194e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.95854675647376614e-02</second>
+						<second>3.05574073991248696e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.26209292166627085e+00</second>
+						<second>1.26216267821064454e+00</second>
 					</item>
 				</goal_state>
-				<score>3.24930532361811997e+00</score>
+				<score>2.08379644332833180e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50265,31 +50265,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78988494173564594e+00</second>
+						<second>1.91979999481988894e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>-1.07463045519840983e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.09599932747134110e+00</second>
+						<second>-1.06800680784612001e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.42539662353259233e+00</second>
+						<second>2.64632987482080706e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.44191236159047564e+00</second>
+						<second>-2.67988961871510778e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.88947035033986049e-01</second>
+						<second>-8.78667964518663192e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87544630355926167e+00</second>
+						<second>2.02095968572544260e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50297,34 +50297,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.64573888600186180e+00</second>
+						<second>1.72423495221193912e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96699999969581896e+00</second>
+						<second>1.84860451671283702e-03</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.84637701288958467e-01</second>
+						<second>-8.75113884915290630e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.42861401861503667e+00</second>
+						<second>2.49872065509601748e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.39151560414778341e+00</second>
+						<second>-2.53078665641735467e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.10783255383787838e+00</second>
+						<second>1.32093848525640933e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.02189078763496344e+00</second>
+						<second>2.02200223631813802e+00</second>
 					</item>
 				</goal_state>
-				<score>2.11141672573532224e+00</score>
+				<score>1.32942997810256203e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50355,31 +50355,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91559279722673237e+00</second>
+						<second>1.84016620003968745e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>3.33659334539958344e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44877935491392051e+00</second>
+						<second>-1.15172648805202638e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27267919981740985e+00</second>
+						<second>2.41806161390585039e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.39744767907745171e+00</second>
+						<second>-2.45691762540465142e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.95854675647376614e-02</second>
+						<second>3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.26209292166627085e+00</second>
+						<second>1.64533671203304799e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50387,34 +50387,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78988494173564594e+00</second>
+						<second>1.85699862849616748e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>-4.33535448190673356e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.09599932747134110e+00</second>
+						<second>-1.08598810411204072e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.42539662353259233e+00</second>
+						<second>2.51033129699827962e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.44191236159047564e+00</second>
+						<second>-2.54514264956715852e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.88947035033986049e-01</second>
+						<second>3.03939859154770353e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87544630355926167e+00</second>
+						<second>1.87557873682776521e+00</second>
 					</item>
 				</goal_state>
-				<score>2.50007206205944099e+00</score>
+				<score>1.59268866763623701e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50445,31 +50445,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.85699862849616748e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-4.33535448190673356e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.08598810411204072e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.51033129699827962e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.54514264956715852e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>3.03939859154770353e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.87557873682776521e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50477,34 +50477,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91969890351458461e+00</second>
+						<second>1.91977003543116287e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96320782660357018e+00</second>
+						<second>-1.78254038665974585e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37175494457080327e+00</second>
+						<second>-1.37173676789760401e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.39425974887273663e+00</second>
+						<second>2.39438024017032269e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.50759068322008760e+00</second>
+						<second>-2.50768358416143178e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13136781864708441e-01</second>
+						<second>2.92843535013849987e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.55297671528658121e+00</second>
+						<second>1.55297723773787522e+00</second>
 					</item>
 				</goal_state>
-				<score>3.08622522320939607e+00</score>
+				<score>1.97969845027953006e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50535,31 +50535,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.89569321515894895e+00</second>
+						<second>-1.86772822812696182e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.64819160821773622e-02</second>
+						<second>2.87681627637262149e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.87307325652369361e-01</second>
+						<second>1.38549159699800817e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.58174694566268759e-01</second>
+						<second>-8.28431975884378335e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.63742484459578341e-01</second>
+						<second>6.96355125478039239e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.80622707382781303e-02</second>
+						<second>-2.67795666688493472e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23354092725502440e+00</second>
+						<second>1.55319852710120698e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50567,34 +50567,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.83558856032609041e+00</second>
+						<second>-1.77230653496244694e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.13913293456714887e-01</second>
+						<second>-7.33376172770565521e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.75907662307599755e-01</second>
+						<second>-8.73595581161907497e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-4.36837327782971241e-01</second>
+						<second>-5.18625279468276856e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>3.57913592522296709e-01</second>
+						<second>-2.62974880159214974e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.25839874655268857e-01</second>
+						<second>3.14149996087379124e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.13516441625246101e+00</second>
+						<second>2.13510519039842128e+00</second>
 					</item>
 				</goal_state>
-				<score>1.81293629473299545e+00</score>
+				<score>1.13851228746772865e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50625,31 +50625,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81046877911026249e+00</second>
+						<second>1.91977003543116287e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.66904686269479896e-01</second>
+						<second>-1.78254038665974585e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.61925678195790335e-01</second>
+						<second>-1.37173676789760401e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.55227369477201627e-01</second>
+						<second>2.39438024017032269e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.08913892870775819e-01</second>
+						<second>-2.50768358416143178e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.83019048046749466e-01</second>
+						<second>2.92843535013849987e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23355078064531121e+00</second>
+						<second>1.55297723773787522e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50657,34 +50657,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.82351156045076945e+00</second>
+						<second>1.91979999481988894e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.13157575006690225e-01</second>
+						<second>-1.07463045519840983e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.10013043441297564e+00</second>
+						<second>-1.06800680784612001e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.27130085717839902e-01</second>
+						<second>2.64632987482080706e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.32418792253928608e-01</second>
+						<second>-2.67988961871510778e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.47226508039611881e-01</second>
+						<second>-8.78667964518663192e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.02113601224369965e+00</second>
+						<second>2.02095968572544260e+00</second>
 					</item>
 				</goal_state>
-				<score>2.11572347952623829e+00</score>
+				<score>1.35243742033888142e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50715,31 +50715,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91559279722673237e+00</second>
+						<second>1.85699862849616748e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>-4.33535448190673356e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44877935491392051e+00</second>
+						<second>-1.08598810411204072e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27267919981740985e+00</second>
+						<second>2.51033129699827962e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.39744767907745171e+00</second>
+						<second>-2.54514264956715852e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.95854675647376614e-02</second>
+						<second>3.03939859154770353e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.26209292166627085e+00</second>
+						<second>1.87557873682776521e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50747,34 +50747,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979999999999995e+00</second>
+						<second>1.91968599441190335e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.82760673632296777e+00</second>
+						<second>-3.14668878620086301e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37660958115094534e+00</second>
+						<second>-1.37692751739817809e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44621650391428869e+00</second>
+						<second>2.44564038117911631e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.56649280138700719e+00</second>
+						<second>-2.56604725292720159e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.51352465606452058e-01</second>
+						<second>2.78933503968609031e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.70653508035472745e+00</second>
+						<second>1.70635399774868790e+00</second>
 					</item>
 				</goal_state>
-				<score>2.85395745580648175e+00</score>
+				<score>1.81705092101571292e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50805,31 +50805,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85333067320256317e+00</second>
+						<second>-1.91963427224258631e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.30881332162781309e-02</second>
+						<second>-1.06321828278368571e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.79566541362986065e-01</second>
+						<second>-1.06761424121323212e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.46687038246712265e-01</second>
+						<second>-4.94849851006691543e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.82408828576758486e+00</second>
+						<second>-2.68064966242545166e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14149990651334399e+00</second>
+						<second>3.05462308593289755e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19428903574285172e+00</second>
+						<second>2.02115691010592924e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50837,34 +50837,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.67446121618897736e+00</second>
+						<second>-1.91973107015799105e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.34899667143905022e+00</second>
+						<second>-3.84174933426533194e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.33090137702942313e+00</second>
+						<second>-1.11958063456495127e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.42477255100238143e+00</second>
+						<second>-4.45855037735516213e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.97949679266965806e-01</second>
+						<second>-2.67667205588571555e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-7.50538880634493033e-01</second>
+						<second>2.76802049525265970e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.09694069532142668e+00</second>
+						<second>2.09703766496971200e+00</second>
 					</item>
 				</goal_state>
-				<score>1.86156811361620877e+00</score>
+				<score>1.21412832343530272e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50895,31 +50895,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979945136074881e+00</second>
+						<second>-1.81862692041195051e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.82756000014498987e+00</second>
+						<second>-1.47327249453790360e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37660821856964355e+00</second>
+						<second>-8.86973069373741096e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44626593976193751e+00</second>
+						<second>-3.98272275704297629e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.56648163821221598e+00</second>
+						<second>-2.71869059061943164e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.51462962043233518e-01</second>
+						<second>3.04224795465348175e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.70657169966797695e+00</second>
+						<second>2.19641956548873285e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -50927,34 +50927,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91976366967758727e+00</second>
+						<second>-1.91956561636755452e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.60944675272011439e+00</second>
+						<second>-5.32687440831879355e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.47016038483363554e+00</second>
+						<second>1.47050899253205558e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40928528208225590e+00</second>
+						<second>2.40870602187938543e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.59495987891154334e+00</second>
+						<second>5.46996489311224354e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.49378241225392028e-01</second>
+						<second>-5.49907216735334381e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75229127949802055e+00</second>
+						<second>-1.75214696671932391e+00</second>
 					</item>
 				</goal_state>
-				<score>2.70078461231943301e+00</score>
+				<score>1.73179382661200199e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -50985,31 +50985,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.55879675094240899e+00</second>
+						<second>1.91979984351281407e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.21962202359560168e+00</second>
+						<second>-3.16659256694142299e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44032572623567345e+00</second>
+						<second>9.12683322227841765e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.35026838188262488e+00</second>
+						<second>1.80186106113853245e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.24740522729476444e+00</second>
+						<second>-4.18851739221983710e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.26783084394147716e+00</second>
+						<second>-2.57965262231855452e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.09715294734037361e+00</second>
+						<second>-2.19429789149678722e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51017,34 +51017,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70973868526433348e+00</second>
+						<second>1.91531312279985166e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.13465494141019230e+00</second>
+						<second>4.00835173469679229e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.52541428617519270e+00</second>
+						<second>1.12445766374134570e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.45360459800229069e+00</second>
+						<second>4.52601624800201663e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.45343966798897828e+00</second>
+						<second>-4.74241649928587250e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.07375289197738866e+00</second>
+						<second>3.89266797245549634e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.09834208018544732e+00</second>
+						<second>-2.09824285951932898e+00</second>
 					</item>
 				</goal_state>
-				<score>1.83991615996556024e+00</score>
+				<score>1.21127439603844700e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51075,31 +51075,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.83777401805191576e+00</second>
+						<second>1.91929444038230956e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.29948482025989120e-01</second>
+						<second>1.74170365353391088e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.40819001289928947e+00</second>
+						<second>-1.36814132753961482e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.06314052816798355e-01</second>
+						<second>-2.39694968755328963e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.71139629763152779e-01</second>
+						<second>2.50781863309288777e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.70361972591768396e+00</second>
+						<second>-2.93193987890819763e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.70893215042257629e+00</second>
+						<second>1.55574684140787589e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51107,34 +51107,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.91753940899029285e+00</second>
+						<second>1.91942295837253729e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.38630076404396640e-01</second>
+						<second>5.36010848566006781e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.47465141160044544e+00</second>
+						<second>-1.47344390341995846e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.36657193849569625e-01</second>
+						<second>-2.40753540904715146e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-5.47727285445424372e-01</second>
+						<second>2.59592680805530840e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.58631675793795335e+00</second>
+						<second>-2.58841165911149984e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75073345049836537e+00</second>
+						<second>1.75068936454382484e+00</second>
 					</item>
 				</goal_state>
-				<score>2.70351540240111943e+00</score>
+				<score>1.73298868715786425e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51165,31 +51165,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.21300886886236725e+00</second>
+						<second>-1.84392594343794758e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>9.25358368089294947e-01</second>
+						<second>-1.06870613741542608e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.42533148022140788e+00</second>
+						<second>-1.35036356874902941e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.12794353525002133e+00</second>
+						<second>-3.62701774961848633e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.89877375670479909e+00</second>
+						<second>-2.62061393140722965e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.14254866666904209e-01</second>
+						<second>2.06391667680832613e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.87149589629349333e+00</second>
+						<second>2.19434682050611451e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51197,34 +51197,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78435873864266470e+00</second>
+						<second>-1.90249239864117814e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.20447824058362740e-02</second>
+						<second>-1.11293954879734769e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.74359929360458032e-01</second>
+						<second>-1.37475120593888689e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>4.97106204185592815e-01</second>
+						<second>-3.05434296684739592e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.65602674417055029e+00</second>
+						<second>-2.74281899469910861e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14110255101022950e+00</second>
+						<second>2.00499300264824054e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14343501476974785e+00</second>
+						<second>2.14347953715500594e+00</second>
 					</item>
 				</goal_state>
-				<score>1.79709988676116561e+00</score>
+				<score>1.11534526858620281e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51255,31 +51255,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81878511637749329e+00</second>
+						<second>1.91929444038230956e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.23695875169699032e-01</second>
+						<second>1.74170365353391088e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.46439707977363764e-01</second>
+						<second>-1.36814132753961482e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.42563015188256659e-01</second>
+						<second>-2.39694968755328963e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-4.80643119460821555e-01</second>
+						<second>2.50781863309288777e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.45171057621394994e-01</second>
+						<second>-2.93193987890819763e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23337729625187453e+00</second>
+						<second>1.55574684140787589e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51287,34 +51287,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.83906436319784583e+00</second>
+						<second>1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.72982808796894572e-01</second>
+						<second>9.58696804341297865e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.09009218730911694e+00</second>
+						<second>-1.06604569773986002e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.06907580079819153e-01</second>
+						<second>-2.64890116953483190e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.05064238863279424e-01</second>
+						<second>2.68357242306106158e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.13657257703061959e-01</second>
+						<second>7.62366614336005971e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.01890526354003752e+00</second>
+						<second>2.01873556248738861e+00</second>
 					</item>
 				</goal_state>
-				<score>2.12032625353634829e+00</score>
+				<score>1.35645012276677274e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51345,31 +51345,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91969083767138970e+00</second>
+						<second>1.85440564064621616e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.70271793940365235e-01</second>
+						<second>5.08365499559876588e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44591087455370992e+00</second>
+						<second>1.08932988089394178e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.60750613187769242e-01</second>
+						<second>6.37754121882949887e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.40420978546068298e+00</second>
+						<second>-6.03347158522170579e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>9.37633757738052104e-02</second>
+						<second>-3.03471650105087631e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.27416158315421790e+00</second>
+						<second>-1.87144701088035803e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51377,34 +51377,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91544437884218466e+00</second>
+						<second>1.91972218867099342e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.12174619358087491e-01</second>
+						<second>3.05469334930286496e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.37290611902648529e+00</second>
+						<second>1.37137909146714487e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.97557534291561976e-01</second>
+						<second>6.91175355985620077e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56264616410358848e+00</second>
+						<second>-5.73599850763888641e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.50995670458185027e-01</second>
+						<second>-2.79557268963863814e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70888844528127959e+00</second>
+						<second>-1.70870773285085331e+00</second>
 					</item>
 				</goal_state>
-				<score>2.85412753152060583e+00</score>
+				<score>1.81559577133752204e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51435,31 +51435,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.57494022683167900e+00</second>
+						<second>1.67577807914305432e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-8.12253977106517783e-02</second>
+						<second>-5.48052426609956303e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.58206752544709039e-01</second>
+						<second>1.00680580761082372e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.82877438931468106e-01</second>
+						<second>9.69902869802193646e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.42425104320007545e+00</second>
+						<second>-8.60396210463838851e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.78332158770567428e+00</second>
+						<second>3.13412732235433911e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91968242144955559e+00</second>
+						<second>-1.49959099682830943e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51467,34 +51467,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72650238241159726e+00</second>
+						<second>-1.91968528494759894e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.33441619978613016e-03</second>
+						<second>1.85457373860209196e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.83074256664899360e-01</second>
+						<second>-1.53792169164813397e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.52456667533487300e-01</second>
+						<second>2.76417285989763339e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51825148877141514e+00</second>
+						<second>-2.90174779533684157e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.01021619619021275e+00</second>
+						<second>1.76563494535202214e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.01047804456087098e+00</second>
+						<second>-2.01020190454117786e+00</second>
 					</item>
 				</goal_state>
-				<score>2.15027866264153866e+00</score>
+				<score>1.34760741280232937e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51525,31 +51525,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.84758358655102706e+00</second>
+						<second>1.90688714724360420e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.94028948339715285e-02</second>
+						<second>2.62568492148069155e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.14239666116054228e+00</second>
+						<second>-1.62594994676778737e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.02315007493416132e-01</second>
+						<second>-2.07520682797054024e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.47515566697445655e+00</second>
+						<second>2.32802056144503711e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.93921397284129542e-02</second>
+						<second>3.11740535949788722e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.65804350658088406e+00</second>
+						<second>7.72613168753316870e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51557,34 +51557,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.87075952114819244e+00</second>
+						<second>1.85440564064621616e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.67113597856464770e-02</second>
+						<second>5.08365499559876588e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.08852418379802751e+00</second>
+						<second>1.08932988089394178e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.14256405178844167e-01</second>
+						<second>6.37754121882949887e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56522200803644029e+00</second>
+						<second>-6.03347158522170579e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>8.32558452246696390e-02</second>
+						<second>-3.03471650105087631e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.87156701312481544e+00</second>
+						<second>-1.87144701088035803e+00</second>
 					</item>
 				</goal_state>
-				<score>2.51520398685996627e+00</score>
+				<score>1.59925525647737349e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51615,31 +51615,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.84758358655102706e+00</second>
+						<second>1.90688714724360420e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.94028948339715285e-02</second>
+						<second>2.62568492148069155e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.14239666116054228e+00</second>
+						<second>-1.62594994676778737e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.02315007493416132e-01</second>
+						<second>-2.07520682797054024e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.47515566697445655e+00</second>
+						<second>2.32802056144503711e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.93921397284129542e-02</second>
+						<second>3.11740535949788722e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.65804350658088406e+00</second>
+						<second>7.72613168753316870e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51647,34 +51647,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91975467083432294e+00</second>
+						<second>1.91929444038230956e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.73144822005593169e-01</second>
+						<second>1.74170365353391088e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.36793298637698402e+00</second>
+						<second>-1.36814132753961482e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.43654138534047160e-01</second>
+						<second>-2.39694968755328963e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.50854039664753925e+00</second>
+						<second>2.50781863309288777e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.08862746679711636e-01</second>
+						<second>-2.93193987890819763e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.55586541986482785e+00</second>
+						<second>1.55574684140787589e+00</second>
 					</item>
 				</goal_state>
-				<score>3.08511919355499087e+00</score>
+				<score>1.97821505191479174e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51705,31 +51705,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78435873864266470e+00</second>
+						<second>-1.91959855975022764e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.20447824058362740e-02</second>
+						<second>-1.28718996055976764e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.74359929360458032e-01</second>
+						<second>-1.53801849211403230e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>4.97106204185592815e-01</second>
+						<second>-3.77384210194172010e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.65602674417055029e+00</second>
+						<second>-2.90169555944808888e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14110255101022950e+00</second>
+						<second>1.76533960843441839e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14343501476974785e+00</second>
+						<second>2.01025235394594670e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51737,34 +51737,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67756094309292059e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-6.82614998071476159e-02</second>
+						<second>-1.38760210493103275e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.03509008083386855e-01</second>
+						<second>-1.59666258587359522e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.51979470162094654e-01</second>
+						<second>-3.87272960346193740e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.42928436442517137e+00</second>
+						<second>-3.09013511379292494e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.84175859876266879e+00</second>
+						<second>1.65782922603420246e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.84177391663201684e+00</second>
+						<second>1.84170789159214432e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55960584936492008e+00</score>
+				<score>1.61728453660857752e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51795,31 +51795,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.81748038472686546e+00</second>
+						<second>1.67577807914305432e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.05483179002218712e-02</second>
+						<second>-5.48052426609956303e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.52649683277555126e+00</second>
+						<second>1.00680580761082372e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.95974397519865740e-01</second>
+						<second>9.69902869802193646e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.27705592182947392e+00</second>
+						<second>-8.60396210463838851e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.71899846432171077e-01</second>
+						<second>3.13412732235433911e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.41654345881488952e-01</second>
+						<second>-1.49959099682830943e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51827,34 +51827,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.84758358655102706e+00</second>
+						<second>1.83145356244103441e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.94028948339715285e-02</second>
+						<second>-2.68012973472397525e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.14239666116054228e+00</second>
+						<second>1.14153088010980364e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.02315007493416132e-01</second>
+						<second>7.26635519296351395e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.47515566697445655e+00</second>
+						<second>-6.89711195472756944e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.93921397284129542e-02</second>
+						<second>3.14148606068921454e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.65804350658088406e+00</second>
+						<second>-1.65794172012047003e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88344875480654794e+00</score>
+				<score>1.88969468201037855e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51885,31 +51885,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.84758358655102706e+00</second>
+						<second>1.84877581835313398e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.94028948339715285e-02</second>
+						<second>1.61449424011855386e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.14239666116054228e+00</second>
+						<second>-1.33385397201176681e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.02315007493416132e-01</second>
+						<second>-2.17579407885300879e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.47515566697445655e+00</second>
+						<second>2.31106718007068812e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.93921397284129542e-02</second>
+						<second>-3.12165043328653802e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.65804350658088406e+00</second>
+						<second>1.13935167011990646e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -51917,34 +51917,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91969083767138970e+00</second>
+						<second>1.91979978245099003e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.70271793940365235e-01</second>
+						<second>1.69860665459021537e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44591087455370992e+00</second>
+						<second>-1.44577369183146764e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.60750613187769242e-01</second>
+						<second>-2.28129697108147322e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.40420978546068298e+00</second>
+						<second>2.40443931959463431e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>9.37633757738052104e-02</second>
+						<second>-3.04803294636414890e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.27416158315421790e+00</second>
+						<second>1.27434608914274317e+00</second>
 					</item>
 				</goal_state>
-				<score>3.25586601630836903e+00</score>
+				<score>2.08383840067579734e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -51975,31 +51975,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80048301098270747e+00</second>
+						<second>1.91895188268619310e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84968805161785999e+00</second>
+						<second>-1.63614066927824409e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84748430205586645e+00</second>
+						<second>-1.65142534439232080e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.46332549145983482e-01</second>
+						<second>2.72420832491494869e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.98662348788025467e+00</second>
+						<second>3.02104830647267653e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.20534791554624299e+00</second>
+						<second>-1.72737568474998859e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.71109707139616929e+00</second>
+						<second>1.71091067947486164e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52007,34 +52007,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.82941622077009791e+00</second>
+						<second>1.91979827456114727e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.88088986423977245e+00</second>
+						<second>-1.69310934468971097e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.78605790741710413e+00</second>
+						<second>-1.64853490051160256e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.83761554474239697e-01</second>
+						<second>2.66337612925651879e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.80387166321470271e+00</second>
+						<second>2.83434571762177168e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.25456778980536288e+00</second>
+						<second>-1.74331291075334316e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44918559034931538e+00</second>
+						<second>1.44908420078067524e+00</second>
 					</item>
 				</goal_state>
-				<score>3.20796298364267729e+00</score>
+				<score>2.04102212499084390e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52065,31 +52065,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60176987721037456e+00</second>
+						<second>1.90027721862750276e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-7.45731572692133055e-02</second>
+						<second>-9.41233110306930881e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.36846937573378558e+00</second>
+						<second>1.33619557762236463e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.54855432878719546e-01</second>
+						<second>8.62490195606291254e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.18143121899762260e+00</second>
+						<second>-7.73491906301295495e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.40819129955978550e-01</second>
+						<second>3.11972931924754437e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.33444492832379469e-01</second>
+						<second>-1.13897893672029671e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52097,34 +52097,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69842527437781610e+00</second>
+						<second>1.67577807914305432e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-9.92130704492299453e-02</second>
+						<second>-5.48052426609956303e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.00863692662598292e+00</second>
+						<second>1.00680580761082372e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.42238626169744853e-01</second>
+						<second>9.69902869802193646e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.30919294546896570e+00</second>
+						<second>-8.60396210463838851e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.35519750969554569e-02</second>
+						<second>3.13412732235433911e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49960548086532408e+00</second>
+						<second>-1.49959099682830943e+00</second>
 					</item>
 				</goal_state>
-				<score>3.13203462616953177e+00</score>
+				<score>1.99337392297207011e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52155,31 +52155,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.68108994411440271e+00</second>
+						<second>1.85750024321031804e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.60692651893204874e-01</second>
+						<second>3.86112805499796596e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13464955382387300e+00</second>
+						<second>-1.64087809787521866e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.28696368104397285e-01</second>
+						<second>-1.94468278479548484e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.44684043752972680e-01</second>
+						<second>2.28360301821369260e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.83940461281481138e+00</second>
+						<second>-3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87150972942930149e+00</second>
+						<second>7.72637201532954010e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52187,34 +52187,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73842889198682360e+00</second>
+						<second>1.70447803004636689e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.31062264819062030e-01</second>
+						<second>2.92685711411266480e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.34738654217196774e+00</second>
+						<second>-1.35552609960947645e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.15795904506851954e+00</second>
+						<second>-1.93002576432736817e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-9.41020427566093720e-01</second>
+						<second>2.16947495371266497e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.05874294179665052e+00</second>
+						<second>-3.04485318321835052e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.13907097944374924e+00</second>
+						<second>1.13907168317813379e+00</second>
 					</item>
 				</goal_state>
-				<score>2.97732187247696656e+00</score>
+				<score>2.08216857454895599e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52245,31 +52245,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.84877581835313398e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.61449424011855386e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.33385397201176681e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.17579407885300879e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.31106718007068812e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-3.12165043328653802e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.13935167011990646e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52277,34 +52277,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85805360557982602e+00</second>
+						<second>1.85750024321031804e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.75689468355472123e+00</second>
+						<second>3.86112805499796596e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64063811762531331e+00</second>
+						<second>-1.64087809787521866e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.94618515104317380e+00</second>
+						<second>-1.94468278479548484e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.57506152855927795e-01</second>
+						<second>2.28360301821369260e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14149939473886430e+00</second>
+						<second>-3.14150000000000018e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.72739521482828651e-01</second>
+						<second>7.72637201532954010e-01</second>
 					</item>
 				</goal_state>
-				<score>2.59969201292127350e+00</score>
+				<score>1.65658940126433729e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52335,31 +52335,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78773248346576441e+00</second>
+						<second>-1.47784374312398392e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.77837666166757424e+00</second>
+						<second>8.31696445979923205e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.79446502359811144e+00</second>
+						<second>1.42550387798338285e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.78973881227557063e-01</second>
+						<second>-7.53418848014226206e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.66580929203518568e+00</second>
+						<second>-9.09934068372391547e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.04684989523332916e+00</second>
+						<second>1.14356427137096262e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.04573451725265532e+00</second>
+						<second>5.19386002032426020e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52367,34 +52367,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.79690243135123939e+00</second>
+						<second>-1.79264590304836680e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.99895877951538581e+00</second>
+						<second>1.12936130557474002e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.59349018850455471e+00</second>
+						<second>1.59891599782539906e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.61671754468278306e-01</second>
+						<second>-6.75877104568412879e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.49004642236794016e+00</second>
+						<second>-6.54328704388791760e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.00722778006336489e+00</second>
+						<second>-1.01251934858351289e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.35672834107230789e-01</second>
+						<second>9.35126084073943153e-01</second>
 					</item>
 				</goal_state>
-				<score>2.74544013012387067e+00</score>
+				<score>1.93510738629231460e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52425,31 +52425,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.82941622077009791e+00</second>
+						<second>-1.62204581966640293e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.88088986423977245e+00</second>
+						<second>1.08102467888642284e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.78605790741710413e+00</second>
+						<second>1.52946483624860585e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.83761554474239697e-01</second>
+						<second>-5.88249462009932333e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.80387166321470271e+00</second>
+						<second>-7.40633536068927234e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.25456778980536288e+00</second>
+						<second>1.22929089651799295e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44918559034931538e+00</second>
+						<second>7.90779347791297660e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52457,34 +52457,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979357504961667e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.61502411204366303e+00</second>
+						<second>1.52846641891744595e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.53888903315315773e+00</second>
+						<second>1.53791882417744152e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.58815071711967415e-01</second>
+						<second>-3.56672294388897915e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.62916678194861175e+00</second>
+						<second>-5.11872845954804534e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-8.75176059586640576e-01</second>
+						<second>-8.74031105951430076e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.08020001710103131e+00</second>
+						<second>1.08117850544307936e+00</second>
 					</item>
 				</goal_state>
-				<score>3.07019943506727611e+00</score>
+				<score>2.05740964019810763e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52515,31 +52515,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73842889198682360e+00</second>
+						<second>1.67347403911628567e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.31062264819062030e-01</second>
+						<second>-1.75237235538530678e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.34738654217196774e+00</second>
+						<second>-1.56317993637410235e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.15795904506851954e+00</second>
+						<second>2.72519367814248392e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-9.41020427566093720e-01</second>
+						<second>2.48926133792774484e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.05874294179665052e+00</second>
+						<second>-1.68283541451774132e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.13907097944374924e+00</second>
+						<second>8.43580083101695410e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52547,34 +52547,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979657922328539e+00</second>
+						<second>-1.91979658850333168e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-8.04181576632448047e-01</second>
+						<second>-8.04179872455525246e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.33648922376973767e+00</second>
+						<second>1.33648897908759978e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.82756274306574751e+00</second>
+						<second>-2.82756109056481675e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.05940371640343312e-01</second>
+						<second>-6.05941216679393047e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.81922546784025740e-01</second>
+						<second>-4.81921688647990454e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.04553106474463164e+00</second>
+						<second>-1.04553026542366734e+00</second>
 					</item>
 				</goal_state>
-				<score>2.96382541879388084e+00</score>
+				<score>2.04298339199516676e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52605,31 +52605,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.85805360557982602e+00</second>
+						<second>1.90688714724360420e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.75689468355472123e+00</second>
+						<second>2.62568492148069155e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64063811762531331e+00</second>
+						<second>-1.62594994676778737e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.94618515104317380e+00</second>
+						<second>-2.07520682797054024e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-8.57506152855927795e-01</second>
+						<second>2.32802056144503711e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.14149939473886430e+00</second>
+						<second>3.11740535949788722e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.72739521482828651e-01</second>
+						<second>7.72613168753316870e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52637,34 +52637,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.81748038472686546e+00</second>
+						<second>1.76432817561318123e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.05483179002218712e-02</second>
+						<second>2.11712100485856397e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.52649683277555126e+00</second>
+						<second>-1.53271451812852777e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.95974397519865740e-01</second>
+						<second>-2.06168832613968123e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.27705592182947392e+00</second>
+						<second>2.22295139329342017e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.71899846432171077e-01</second>
+						<second>2.90592092287403103e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>6.41654345881488952e-01</second>
+						<second>6.42331693122109026e-01</second>
 					</item>
 				</goal_state>
-				<score>2.16823251488438951e+00</score>
+				<score>1.50678625955759787e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52695,31 +52695,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.56462825203793021e+00</second>
+						<second>-1.56090686850074256e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.15610684099707095e+00</second>
+						<second>8.65711298706078547e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.71305861025194162e+00</second>
+						<second>1.59716568055840979e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.32983370913493371e+00</second>
+						<second>-7.99928111239701312e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.42867529052722730e+00</second>
+						<second>-7.86596714875529068e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.83677130336604399e+00</second>
+						<second>1.15593703262247849e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.43433687284591116e-01</second>
+						<second>7.90846383785591023e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52727,34 +52727,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.48923496664104738e+00</second>
+						<second>-1.47784374312398392e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.25065311632395559e+00</second>
+						<second>8.31696445979923205e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.41434574949438252e+00</second>
+						<second>1.42550387798338285e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44687790582781695e+00</second>
+						<second>-7.53418848014226206e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.24143394036810983e+00</second>
+						<second>-9.09934068372391547e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.98500457715291523e+00</second>
+						<second>1.14356427137096262e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>5.19425780294794914e-01</second>
+						<second>5.19386002032426020e-01</second>
 					</item>
 				</goal_state>
-				<score>1.80804794091836873e+00</score>
+				<score>1.22674471404458224e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52785,31 +52785,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85561443089747624e+00</second>
+						<second>-1.84459178394975121e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.94924173106034626e+00</second>
+						<second>1.08609943140995324e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.68721554220585879e+00</second>
+						<second>1.58745100595908295e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.36615599819230549e-01</second>
+						<second>-6.18984881651324037e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.69542266508565564e+00</second>
+						<second>-5.41546128749344713e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.19322003540887067e+00</second>
+						<second>1.08200643783924799e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32816737869660728e+00</second>
+						<second>1.22486381748406625e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52817,34 +52817,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.63223108688898666e+00</second>
+						<second>-1.62204581966640293e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.01777752284855882e+00</second>
+						<second>1.08102467888642284e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.51494615570768176e+00</second>
+						<second>1.52946483624860585e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-5.45570727533466138e-01</second>
+						<second>-5.88249462009932333e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.40847590031933034e+00</second>
+						<second>-7.40633536068927234e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.24525430535861514e+00</second>
+						<second>1.22929089651799295e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.90981838959245120e-01</second>
+						<second>7.90779347791297660e-01</second>
 					</item>
 				</goal_state>
-				<score>2.57147490887186558e+00</score>
+				<score>1.74334388783651761e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52875,31 +52875,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979657922328539e+00</second>
+						<second>1.91971078423910901e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-8.04181576632448047e-01</second>
+						<second>-1.69326286021334993e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.33648922376973767e+00</second>
+						<second>-1.64865919516368464e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.82756274306574751e+00</second>
+						<second>2.66318434326514009e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.05940371640343312e-01</second>
+						<second>2.83434441791442060e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.81922546784025740e-01</second>
+						<second>-1.74324732117652270e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.04553106474463164e+00</second>
+						<second>1.44910393801641724e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52907,34 +52907,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71314035154437549e+00</second>
+						<second>1.67347403911628567e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.34636628965096250e+00</second>
+						<second>-1.75237235538530678e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.39934618090105012e+00</second>
+						<second>-1.56317993637410235e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.14150000000000018e+00</second>
+						<second>2.72519367814248392e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.55949512670593649e-01</second>
+						<second>2.48926133792774484e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.64796301150958535e+00</second>
+						<second>-1.68283541451774132e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.43357426664944620e-01</second>
+						<second>8.43580083101695410e-01</second>
 					</item>
 				</goal_state>
-				<score>2.79564436174218267e+00</score>
+				<score>1.83089411875224900e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -52965,31 +52965,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.91979657922328539e+00</second>
+						<second>-1.89062853030974298e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-8.04181576632448047e-01</second>
+						<second>2.47812374602058849e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.33648922376973767e+00</second>
+						<second>1.29215642101211614e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.82756274306574751e+00</second>
+						<second>4.60230709884764666e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-6.05940371640343312e-01</second>
+						<second>-6.56752624293201803e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.81922546784025740e-01</second>
+						<second>-4.06282424888026517e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.04553106474463164e+00</second>
+						<second>1.04555269621878000e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -52997,34 +52997,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73322128858838376e+00</second>
+						<second>-1.71616172891419017e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-7.56934011802913309e-01</second>
+						<second>2.52597643930822358e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.44654564584594425e+00</second>
+						<second>1.42050371498632377e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.84850768186289915e+00</second>
+						<second>4.34868186917234278e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-7.82237228692500453e-01</second>
+						<second>-8.14288531309570907e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-6.23607933111390511e-01</second>
+						<second>-5.78301173476428954e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-6.33026351151945388e-01</second>
+						<second>6.33048208113299649e-01</second>
 					</item>
 				</goal_state>
-				<score>2.15576692900806233e+00</score>
+				<score>1.51377195576577805e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -54765,31 +54765,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.53153345297258481e+00</second>
+						<second>-1.59776766259076775e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.73943185941435696e-01</second>
+						<second>2.60202680172252743e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.64748772216048933e+00</second>
+						<second>-1.45737328521461573e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.24390878253930492e+00</second>
+						<second>8.56409638234790216e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.06621847443260465e-01</second>
+						<second>-2.33819393888494975e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.04786014836411012e+00</second>
+						<second>-6.33958760656410436e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.81651032287610903e-01</second>
+						<second>1.08391146336673549e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -54797,34 +54797,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.50527518949420713e+00</second>
+						<second>-1.54707485718729032e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-4.57686113309499765e-01</second>
+						<second>2.50980779645780316e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.43028405084706534e+00</second>
+						<second>-1.40980425143219157e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.22856019152355644e+00</second>
+						<second>1.05191792610538815e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.99573877707567893e-01</second>
+						<second>-2.17608059307534196e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.09764371279093997e+00</second>
+						<second>-1.11699047825362596e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.70755720247307163e-01</second>
+						<second>4.70546410727397668e-01</second>
 					</item>
 				</goal_state>
-				<score>1.65021444059937239e+00</score>
+				<score>1.13527797306187200e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -54855,31 +54855,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.70299771536135802e+00</second>
+						<second>-1.56289893854326278e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.54776187788791431e+00</second>
+						<second>-7.02319065880676274e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.67816476860129482e+00</second>
+						<second>1.39999458963481982e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46313977189441324e+00</second>
+						<second>9.80193026467913842e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.58374943579392680e+00</second>
+						<second>9.52717867870870649e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.60984221714968312e+00</second>
+						<second>-1.12679871429739697e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.59165367273433911e+00</second>
+						<second>4.70682505785254224e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -54887,34 +54887,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.62196630904671402e+00</second>
+						<second>-1.62839666540139971e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.43542979652923686e+00</second>
+						<second>-7.23792288677169715e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.59983928955559263e+00</second>
+						<second>1.59561679669348777e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.12090343725375918e+00</second>
+						<second>1.00369723572464609e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.30617409020898867e+00</second>
+						<second>8.30442816289897134e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.05162056665249271e+00</second>
+						<second>-1.09415767642935702e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.81830307155014115e-01</second>
+						<second>7.81831998526192673e-01</second>
 					</item>
 				</goal_state>
-				<score>2.46515399237530142e+00</score>
+				<score>1.73814741816750995e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -55035,31 +55035,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36234264325357590e+00</second>
+						<second>-1.40487543207071242e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.08630571727141700e-01</second>
+						<second>2.64072670821684685e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.74558457735316463e-01</second>
+						<second>-9.56039283682423413e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.87467967159666782e-01</second>
+						<second>7.73730913536543219e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.02828768302830720e+00</second>
+						<second>-2.16624570371707570e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.69672469130647841e-01</second>
+						<second>-6.05420871205249123e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.55924194813239925e-01</second>
+						<second>4.56092952543910690e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55067,34 +55067,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.37868660879675220e+00</second>
+						<second>-1.42058343568988232e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.40007595017355890e-01</second>
+						<second>2.60711221640345281e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.02958257629769623e+00</second>
+						<second>-1.01043170033424112e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.02398841271607077e+00</second>
+						<second>8.11564424436403309e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.04055737191193343e+00</second>
+						<second>-2.14909668908773055e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-6.50208787367546726e-01</second>
+						<second>-6.82719939402355425e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.41354093869825770e-01</second>
+						<second>4.41352549137533412e-01</second>
 					</item>
 				</goal_state>
-				<score>1.35611262663608856e+00</score>
+				<score>8.68322964042722023e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55125,31 +55125,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63789170127869665e+00</second>
+						<second>-1.56590987885104527e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.72265959196362317e+00</second>
+						<second>2.73508377575507700e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33038523130822028e+00</second>
+						<second>-1.12147570896099480e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.43139997145057940e+00</second>
+						<second>7.06597154260052984e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.40184537534954812e+00</second>
+						<second>-2.34006051921131064e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.77026608971712918e+00</second>
+						<second>-3.75781163523127515e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22576411079849779e+00</second>
+						<second>9.53332224826171415e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55157,34 +55157,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.54713906694333425e+00</second>
+						<second>-1.54624584877524374e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.63398341239725253e+00</second>
+						<second>2.63614967002567235e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.25716559381732962e+00</second>
+						<second>-1.25770653161430457e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.32838380521795507e+00</second>
+						<second>8.15436772439950275e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.26719643059508202e+00</second>
+						<second>-2.26632583874303783e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.53883578068425209e+00</second>
+						<second>-6.01910718019064150e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.56747353068549877e-01</second>
+						<second>8.56916243826249091e-01</second>
 					</item>
 				</goal_state>
-				<score>2.54832879623493280e+00</score>
+				<score>1.64837868553831285e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55215,31 +55215,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.57091295634294092e+00</second>
+						<second>-1.54737425223645841e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.69931498690806526e+00</second>
+						<second>2.63314552490189957e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.18417883286046810e+00</second>
+						<second>-1.25706383741706840e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.42359385619014889e+00</second>
+						<second>8.12585237455080933e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.32876080016412912e+00</second>
+						<second>-2.26753815754620280e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.70553644953476224e+00</second>
+						<second>-6.03172474370826883e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.66565966861221537e-01</second>
+						<second>8.56754944443759214e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55247,34 +55247,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.59973861058203526e+00</second>
+						<second>-1.59776766259076775e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.59812708766042544e+00</second>
+						<second>2.60202680172252743e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.45622386142042370e+00</second>
+						<second>-1.45737328521461573e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.28911309463765589e+00</second>
+						<second>8.56409638234790216e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.34011097899251208e+00</second>
+						<second>-2.33819393888494975e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.50595263101389909e+00</second>
+						<second>-6.33958760656410436e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.08390507285924076e+00</second>
+						<second>1.08391146336673549e+00</second>
 					</item>
 				</goal_state>
-				<score>3.03031092297025806e+00</score>
+				<score>1.96322727368690053e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55305,31 +55305,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.70299771536135802e+00</second>
+						<second>-1.82071524295609821e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.54776187788791431e+00</second>
+						<second>-1.17133520791414081e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.67816476860129482e+00</second>
+						<second>1.58671260971700745e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46313977189441324e+00</second>
+						<second>6.44679715106950324e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.58374943579392680e+00</second>
+						<second>6.42023042292822810e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.60984221714968312e+00</second>
+						<second>9.88962308619349528e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.59165367273433911e+00</second>
+						<second>9.43350516746099044e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55337,34 +55337,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.66260166713750435e+00</second>
+						<second>-1.66982193267615031e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.46923518546951071e+00</second>
+						<second>-6.86233117885031496e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.60288543480526613e+00</second>
+						<second>1.59769393260554260e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.28744035468030749e+00</second>
+						<second>8.40829398075849777e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.42815624750602188e+00</second>
+						<second>7.06956255598544470e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.37686494249028391e+00</second>
+						<second>-7.71204431263794010e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.19617077588841303e+00</second>
+						<second>1.19620356939663774e+00</second>
 					</item>
 				</goal_state>
-				<score>3.29221602511247102e+00</score>
+				<score>2.07209232177577418e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55395,31 +55395,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.76577378666234819e+00</second>
+						<second>-1.91979968470895024e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.99664117009518804e+00</second>
+						<second>-1.49964250960235845e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.86796749162818920e+00</second>
+						<second>1.54994287566443889e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.34730382106805679e+00</second>
+						<second>3.90855829114082121e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.78163388304197534e+00</second>
+						<second>5.23127033081822623e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.96675406574584533e+00</second>
+						<second>8.75615975044806927e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.46463993745789089e+00</second>
+						<second>1.06231214406949270e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55427,34 +55427,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81285670128973808e+00</second>
+						<second>-1.77802400196674837e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.12697259168847008e+00</second>
+						<second>-9.40672466431703325e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62395732420834604e+00</second>
+						<second>1.66070150670053418e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.43986013177225614e+00</second>
+						<second>7.77440168091855566e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.57072429698229943e+00</second>
+						<second>5.95745499192110839e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.09576922517238629e+00</second>
+						<second>-1.00675255858275570e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.20888429590384461e+00</second>
+						<second>1.20885132837724596e+00</second>
 					</item>
 				</goal_state>
-				<score>3.15611394441710225e+00</score>
+				<score>2.09137368207154811e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55485,31 +55485,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.78806346143353867e+00</second>
+						<second>-1.91978252683742800e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.04455237902934917e+00</second>
+						<second>-1.44028423254754889e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.82930748460479142e+00</second>
+						<second>1.65639506953282445e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48374742953864791e+00</second>
+						<second>4.85737992964276111e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.86426652995970032e+00</second>
+						<second>2.98587233686228193e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11474088779904079e+00</second>
+						<second>-1.38851267242427379e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.67060792421692006e+00</second>
+						<second>1.46458532290340715e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55517,34 +55517,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.80911257615387355e+00</second>
+						<second>-1.91979828943516240e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.04714581084618308e+00</second>
+						<second>-1.34207937161182378e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.74866681539752067e+00</second>
+						<second>1.59380624605154675e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.39670773105489099e+00</second>
+						<second>4.76934006141843669e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.66606869262181734e+00</second>
+						<second>4.18310862573718856e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.00421279641524519e+00</second>
+						<second>-1.30178228789807804e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32190138546781766e+00</second>
+						<second>1.32179242655558049e+00</second>
 					</item>
 				</goal_state>
-				<score>3.22891375103269285e+00</score>
+				<score>2.09628432685958627e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55575,31 +55575,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.66066501829163360e+00</second>
+						<second>-1.63469438704071224e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81983341164286960e+00</second>
+						<second>2.86374081108966827e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.15459929940201778e+00</second>
+						<second>-1.16547871099548850e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51672498306495340e+00</second>
+						<second>6.81807224991277216e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.46768754438344295e+00</second>
+						<second>-2.42983401325856363e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.93849379968647062e+00</second>
+						<second>-1.68808488371877924e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.21428875815116966e+00</second>
+						<second>1.21464747888233204e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55607,34 +55607,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.57091295634294092e+00</second>
+						<second>-1.54803260150585387e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.69931498690806526e+00</second>
+						<second>2.74954985023121878e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.18417883286046810e+00</second>
+						<second>-1.19588210502539560e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.42359385619014889e+00</second>
+						<second>7.76023130190381827e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.32876080016412912e+00</second>
+						<second>-2.30037075350068321e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.70553644953476224e+00</second>
+						<second>-4.11371511229931097e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.66565966861221537e-01</second>
+						<second>9.66584971261667314e-01</second>
 					</item>
 				</goal_state>
-				<score>2.67899184079623343e+00</score>
+				<score>1.68228708091431700e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55665,31 +55665,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64888339505604864e+00</second>
+						<second>-1.56590987885104527e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.75682184723469170e+00</second>
+						<second>2.73508377575507700e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.26193275250488424e+00</second>
+						<second>-1.12147570896099480e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46315423693026769e+00</second>
+						<second>7.06597154260052984e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.42313967424857468e+00</second>
+						<second>-2.34006051921131064e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83605072481505216e+00</second>
+						<second>-3.75781163523127515e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22314063803218565e+00</second>
+						<second>9.53332224826171415e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55697,34 +55697,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63782262945032153e+00</second>
+						<second>-1.63353337045957736e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.72278408328315136e+00</second>
+						<second>2.73037589193987085e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33042212143335248e+00</second>
+						<second>-1.33268258536659157e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.43126075113853934e+00</second>
+						<second>7.18709444713002021e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.40176035966014290e+00</second>
+						<second>-2.39661633669648166e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.77034644711207134e+00</second>
+						<second>-3.66295208668242833e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22576432327048979e+00</second>
+						<second>1.22587442853921158e+00</second>
 					</item>
 				</goal_state>
-				<score>3.06098562940447394e+00</score>
+				<score>1.91761004031403226e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55755,31 +55755,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64093076962699436e+00</second>
+						<second>-1.59776766259076775e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.50967640588486063e+00</second>
+						<second>2.60202680172252743e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.61759321053386107e+00</second>
+						<second>-1.45737328521461573e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.24879611565712656e+00</second>
+						<second>8.56409638234790216e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.40898542420573980e+00</second>
+						<second>-2.33819393888494975e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.39496454987968033e+00</second>
+						<second>-6.33958760656410436e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.19617507519897037e+00</second>
+						<second>1.08391146336673549e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55787,34 +55787,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.68301357575729349e+00</second>
+						<second>-1.65986602325390842e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.65697582283300804e+00</second>
+						<second>2.69586891562322073e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.51487276603243370e+00</second>
+						<second>-1.52849038831270456e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.44852104919066837e+00</second>
+						<second>7.31069649913892561e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.48564476195746176e+00</second>
+						<second>-2.45819055046208090e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71820666542824885e+00</second>
+						<second>-3.96062889405085439e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44020025755015957e+00</second>
+						<second>1.44019108722580302e+00</second>
 					</item>
 				</goal_state>
-				<score>3.17033239437755254e+00</score>
+				<score>1.98614688420177904e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55845,31 +55845,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71489693352731076e+00</second>
+						<second>-1.79252766173970324e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.48138237356416980e+00</second>
+						<second>-5.79391854082466518e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.89295844814681269e+00</second>
+						<second>1.69028545771684757e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50584235246842679e+00</second>
+						<second>5.56704019387670224e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.80701950340557760e+00</second>
+						<second>3.93063297904680975e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.60033381886341974e+00</second>
+						<second>-4.45211141109628283e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91467729556806998e+00</second>
+						<second>1.82027716872494927e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55877,34 +55877,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73028272880656697e+00</second>
+						<second>-1.73314203561712987e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.50086010196754316e+00</second>
+						<second>-6.45722535850085766e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.65600408123794218e+00</second>
+						<second>1.65352349639463192e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50571527616767620e+00</second>
+						<second>6.31188264204018634e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.61511812276850630e+00</second>
+						<second>5.23163705302243320e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.57411688722730059e+00</second>
+						<second>-5.71579814880525117e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.59166046173256048e+00</second>
+						<second>1.59166512108761959e+00</second>
 					</item>
 				</goal_state>
-				<score>3.07384131191527743e+00</score>
+				<score>1.92568873986957240e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -55935,31 +55935,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.70865062545103608e+00</second>
+						<second>-1.91143839745425836e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.17344875257580172e+00</second>
+						<second>-1.03629857753289700e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91889357973545738e+00</second>
+						<second>1.61479732850674251e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.37407948854525985e+00</second>
+						<second>2.96639515668864817e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.80802910408089268e+00</second>
+						<second>8.72836714228682337e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20895421388375013e+00</second>
+						<second>-9.37245045659437448e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.67032604693571773e+00</second>
+						<second>1.91459171058699873e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -55967,34 +55967,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.76343536150351610e+00</second>
+						<second>-1.88687571496942574e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.28917221203157073e+00</second>
+						<second>-1.10293692041362368e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.76356426267541155e+00</second>
+						<second>1.58016654154818537e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51694194520703185e+00</second>
+						<second>3.67735417004154297e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.74860638873879193e+00</second>
+						<second>2.69139495847489918e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.36622373415104859e+00</second>
+						<second>-1.00979053492877346e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.67186848616890305e+00</second>
+						<second>1.67186959973021465e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88103207717149568e+00</score>
+				<score>1.85231681558697181e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56025,31 +56025,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77133114828962057e+00</second>
+						<second>-1.91730574883702753e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.06962357440955902e+00</second>
+						<second>-1.50462831131339603e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.88263107656286777e+00</second>
+						<second>1.65379047724964989e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.58594869083390755e+00</second>
+						<second>4.20459206420563947e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-3.06810168357524304e+00</second>
+						<second>1.21817202680193179e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.21098507136634126e+00</second>
+						<second>-1.41356968423901908e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95033756155668936e+00</second>
+						<second>1.70858982028590112e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56057,34 +56057,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.78883735977529579e+00</second>
+						<second>-1.91979564422531457e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.04325810964676124e+00</second>
+						<second>-1.35118139542503224e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.82834116880776176e+00</second>
+						<second>1.61825201456097489e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48493371917429817e+00</second>
+						<second>3.90926337324061512e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.86477796978246513e+00</second>
+						<second>2.00338143281653058e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11371386212309620e+00</second>
+						<second>-1.26239806628537399e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.67060799679946403e+00</second>
+						<second>1.67051817471754327e+00</second>
 					</item>
 				</goal_state>
-				<score>2.79977746227816171e+00</score>
+				<score>1.85422325811069488e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56115,31 +56115,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66660695309675044e+00</second>
+						<second>-1.91128413571698852e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.83834082934572107e+00</second>
+						<second>-1.58941703890717090e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>7.75532812691213769e-01</second>
+						<second>1.60143037433179036e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.00448727025215434e-01</second>
+						<second>3.35434180887394628e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.47144086508741356e-01</second>
+						<second>-7.96827284117425788e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.68566864315456399e+00</second>
+						<second>-1.49564470006934025e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.92782036673142132e+00</second>
+						<second>1.92775721880974182e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56147,34 +56147,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67761563718845697e+00</second>
+						<second>-1.91979687320324510e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.80706038361905952e+00</second>
+						<second>-1.50995485113510730e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.47464609917325751e-01</second>
+						<second>1.64866239813825355e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.04496150312718816e-01</second>
+						<second>4.14079885731526542e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.56230579649813794e-01</second>
+						<second>1.21530234376617016e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.53873150157934191e+00</second>
+						<second>-1.41932741009181185e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70872047229901081e+00</second>
+						<second>1.70855270118501457e+00</second>
 					</item>
 				</goal_state>
-				<score>2.69433900641181001e+00</score>
+				<score>1.79970767574680279e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56205,31 +56205,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.69660054933453841e+00</second>
+						<second>-1.73271724748362543e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.71568389803189802e+00</second>
+						<second>2.77370847385583374e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75837516174439479e+00</second>
+						<second>-1.55230910103850439e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.45730340318644647e+00</second>
+						<second>6.53810784840472059e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.62338287279903648e+00</second>
+						<second>-2.56671266174037793e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83246440329905003e+00</second>
+						<second>-2.33085573555853492e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82028058326015829e+00</second>
+						<second>1.66901085956085971e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56237,34 +56237,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73110566756165651e+00</second>
+						<second>-1.72435553480150872e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.77635814861694863e+00</second>
+						<second>2.78687915805735509e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.39449278697979873e+00</second>
+						<second>-1.39792329417937045e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51253552210635211e+00</second>
+						<second>6.41074335489871916e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.53253797949373061e+00</second>
+						<second>-2.52325489230090794e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.90805007464500065e+00</second>
+						<second>-2.24265097183591916e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49988536014197904e+00</second>
+						<second>1.49988085612140187e+00</second>
 					</item>
 				</goal_state>
-				<score>3.01336339798945607e+00</score>
+				<score>1.88735203582202526e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56295,31 +56295,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.75129634502055831e+00</second>
+						<second>-1.81641115086587002e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.80861340612210508e+00</second>
+						<second>-2.71997797765203941e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.77186493257984434e+00</second>
+						<second>1.32821739491945268e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.56910839403016800e+00</second>
+						<second>4.90359367093939569e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.72918533337231661e+00</second>
+						<second>4.69573756661680553e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.96770492719931989e+00</second>
+						<second>-1.01762524497854556e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.99583234667512244e+00</second>
+						<second>1.62518737407227754e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56327,34 +56327,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74282958880292793e+00</second>
+						<second>-1.76028465155532365e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.75844943569293477e+00</second>
+						<second>-4.10279679970260824e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.54703146873696928e+00</second>
+						<second>1.53715036924467019e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50270282851143255e+00</second>
+						<second>6.11269108734451838e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.58010848899250789e+00</second>
+						<second>5.37502923923386278e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.89485603392070834e+00</second>
+						<second>-2.71317020886003735e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.66895094830176571e+00</second>
+						<second>1.66913401001993345e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88489552071470179e+00</score>
+				<score>1.80881964331712414e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56385,31 +56385,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.70299771536135802e+00</second>
+						<second>-1.85521367637424106e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.54776187788791431e+00</second>
+						<second>-3.55042910847199633e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.67816476860129482e+00</second>
+						<second>1.52376119278046351e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46313977189441324e+00</second>
+						<second>4.57939525111987600e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.58374943579392680e+00</second>
+						<second>3.76844584685266382e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.60984221714968312e+00</second>
+						<second>-1.92511043846017332e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.59165367273433911e+00</second>
+						<second>1.84025710788886876e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56417,34 +56417,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.76111598476318498e+00</second>
+						<second>-1.75255316938485106e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.61441540644511639e+00</second>
+						<second>-5.13677555698788812e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.71610815864412869e+00</second>
+						<second>1.72244302030857610e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.53875593269465671e+00</second>
+						<second>6.14333184228052276e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.70636165031785714e+00</second>
+						<second>4.46178683405762555e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.74537194027882459e+00</second>
+						<second>-3.83760006965215283e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82027911721189417e+00</second>
+						<second>1.82037133751471836e+00</second>
 					</item>
 				</goal_state>
-				<score>2.64633262546205428e+00</score>
+				<score>1.65680617912674438e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56475,31 +56475,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74785716738495633e+00</second>
+						<second>-1.91878869800007656e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.56418273366954308e+00</second>
+						<second>-1.36070435045604765e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91932273245387908e+00</second>
+						<second>1.58968794733277452e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.62952977680462086e+00</second>
+						<second>2.67170457248482707e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.94376985628729804e+00</second>
+						<second>-3.58440555484355328e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71528210245107626e+00</second>
+						<second>-1.27754336132031843e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.10140549116757347e+00</second>
+						<second>1.95025217010170859e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56507,34 +56507,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71489693352731076e+00</second>
+						<second>-1.91979999994536343e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.48138237356416980e+00</second>
+						<second>-1.05801952135842026e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.89295844814681269e+00</second>
+						<second>1.59365716585247896e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50584235246842679e+00</second>
+						<second>2.71177987218337524e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.80701950340557760e+00</second>
+						<second>7.53577068991500981e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.60033381886341974e+00</second>
+						<second>-9.65774240049035115e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91467729556806998e+00</second>
+						<second>1.91435676601353788e+00</second>
 					</item>
 				</goal_state>
-				<score>2.39748128924333859e+00</score>
+				<score>1.51616590130315809e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56565,31 +56565,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74785716738495633e+00</second>
+						<second>-1.91128413571698852e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.56418273366954308e+00</second>
+						<second>-1.58941703890717090e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91932273245387908e+00</second>
+						<second>1.60143037433179036e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.62952977680462086e+00</second>
+						<second>3.35434180887394628e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.94376985628729804e+00</second>
+						<second>-7.96827284117425788e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71528210245107626e+00</second>
+						<second>-1.49564470006934025e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.10140549116757347e+00</second>
+						<second>1.92775721880974182e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56597,34 +56597,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77133114828962057e+00</second>
+						<second>-1.91979999438480187e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.06962357440955902e+00</second>
+						<second>-1.36319947686496934e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.88263107656286777e+00</second>
+						<second>1.58676759209336371e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.58594869083390755e+00</second>
+						<second>2.64048928422663753e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-3.06810168357524304e+00</second>
+						<second>-3.64039654514912991e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.21098507136634126e+00</second>
+						<second>-1.28091525687063679e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95033756155668936e+00</second>
+						<second>1.95021084246232679e+00</second>
 					</item>
 				</goal_state>
-				<score>2.24219973155004393e+00</score>
+				<score>1.45519164483522812e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56655,31 +56655,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67973706589754679e+00</second>
+						<second>-1.90452249286867903e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.80247613652238581e+00</second>
+						<second>-1.70587212515639175e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.48308855035187159e-01</second>
+						<second>1.50074398715173363e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.02210678060741422e-01</second>
+						<second>2.63818937548294385e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.53157556082115343e-01</second>
+						<second>-2.89383879907489316e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.53680153762953209e+00</second>
+						<second>-1.65285380444310848e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.70868304885012123e+00</second>
+						<second>2.10509473855476736e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56687,34 +56687,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66660695309675044e+00</second>
+						<second>-1.91979999812392799e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.83834082934572107e+00</second>
+						<second>-1.60882511745665924e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>7.75532812691213769e-01</second>
+						<second>1.57910476488882567e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.00448727025215434e-01</second>
+						<second>3.12365956813682177e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.47144086508741356e-01</second>
+						<second>-7.89227743136745458e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.68566864315456399e+00</second>
+						<second>-1.52177846629196201e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.92782036673142132e+00</second>
+						<second>1.92764893023115369e+00</second>
 					</item>
 				</goal_state>
-				<score>2.26602256782084677e+00</score>
+				<score>1.48877010078802524e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56745,31 +56745,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73078968255012589e+00</second>
+						<second>-1.81641115086587002e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>7.47439562092142625e-03</second>
+						<second>-2.71997797765203941e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13176583513988849e+00</second>
+						<second>1.32821739491945268e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.00915333414596575e-01</second>
+						<second>4.90359367093939569e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.68593273285678102e-01</second>
+						<second>4.69573756661680553e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.07673001590367362e-01</second>
+						<second>-1.01762524497854556e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49766195620005260e+00</second>
+						<second>1.62518737407227754e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56777,34 +56777,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68429938207733176e+00</second>
+						<second>-1.81056407518729179e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.40222118714297822e-01</second>
+						<second>-3.13605712878963661e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.46041720974469524e+00</second>
+						<second>1.41867751466451475e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.19731508275365806e-01</second>
+						<second>5.25497232036483575e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.64864492080486480e-01</second>
+						<second>4.83149609135335334e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.23697265304050408e-02</second>
+						<second>-1.45701041314242330e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68232408561779012e+00</second>
+						<second>1.68229419020028992e+00</second>
 					</item>
 				</goal_state>
-				<score>2.77559167773378457e+00</score>
+				<score>1.74692110020286145e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56835,31 +56835,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69489539870812900e+00</second>
+						<second>-1.84365423117329397e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.06356020858098574e-01</second>
+						<second>-2.58642132804804525e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.36316029981210418e+00</second>
+						<second>1.74133771600283604e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.98822107106659596e-01</second>
+						<second>3.54846666988557158e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.56335127311222677e-01</second>
+						<second>2.24464553971724656e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>8.03488596581905384e-02</second>
+						<second>-1.20646644301280623e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.62517132664029740e+00</second>
+						<second>2.12704592348352639e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56867,34 +56867,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68489224071480215e+00</second>
+						<second>-1.85466264246605683e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.10058432653208749e-01</second>
+						<second>-3.54172221069899873e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.58508847215998983e+00</second>
+						<second>1.52413380922498454e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.01743863827361425e-01</second>
+						<second>4.59225743547204190e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.34248571507239345e-01</second>
+						<second>3.77873755577162129e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.09359040907673738e-02</second>
+						<second>-1.91380901447603335e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.84028735871544136e+00</second>
+						<second>1.84020163446183704e+00</second>
 					</item>
 				</goal_state>
-				<score>2.52598125986216182e+00</score>
+				<score>1.59518018828715080e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -56925,31 +56925,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74282958880292793e+00</second>
+						<second>-1.73271724748362543e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.75844943569293477e+00</second>
+						<second>2.77370847385583374e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.54703146873696928e+00</second>
+						<second>-1.55230910103850439e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.50270282851143255e+00</second>
+						<second>6.53810784840472059e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.58010848899250789e+00</second>
+						<second>-2.56671266174037793e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.89485603392070834e+00</second>
+						<second>-2.33085573555853492e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.66895094830176571e+00</second>
+						<second>1.66901085956085971e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -56957,34 +56957,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.75057684866669527e+00</second>
+						<second>-1.74007473741780516e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.80999024257839425e+00</second>
+						<second>2.82681707429333606e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.77223621402302967e+00</second>
+						<second>-1.77745643893563288e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.56813052353909521e+00</second>
+						<second>5.85664152423559736e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.72788169594534002e+00</second>
+						<second>-2.71196831310622866e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.96902939281263123e+00</second>
+						<second>-1.56277612451208886e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.99579337418176017e+00</second>
+						<second>1.99579027926392283e+00</second>
 					</item>
 				</goal_state>
-				<score>2.21809838483436783e+00</score>
+				<score>1.38860763629784417e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -57015,31 +57015,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.69660054933453841e+00</second>
+						<second>-1.91878869800007656e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.71568389803189802e+00</second>
+						<second>-1.36070435045604765e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75837516174439479e+00</second>
+						<second>1.58968794733277452e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.45730340318644647e+00</second>
+						<second>2.67170457248482707e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.62338287279903648e+00</second>
+						<second>-3.58440555484355328e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83246440329905003e+00</second>
+						<second>-1.27754336132031843e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82028058326015829e+00</second>
+						<second>1.95025217010170859e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57047,34 +57047,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74785716738495633e+00</second>
+						<second>-1.91635868843885815e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.56418273366954308e+00</second>
+						<second>-9.61338309424517812e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91932273245387908e+00</second>
+						<second>1.63019133759381707e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.62952977680462086e+00</second>
+						<second>1.87689439512770506e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.94376985628729804e+00</second>
+						<second>-1.03729773995773475e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.71528210245107626e+00</second>
+						<second>-8.95109046536718744e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.10140549116757347e+00</second>
+						<second>2.10145264616564287e+00</second>
 					</item>
 				</goal_state>
-				<score>1.91392628560236422e+00</score>
+				<score>1.20173636098180756e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -57105,31 +57105,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66660695309675044e+00</second>
+						<second>-1.91878869800007656e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.83834082934572107e+00</second>
+						<second>-1.36070435045604765e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>7.75532812691213769e-01</second>
+						<second>1.58968794733277452e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.00448727025215434e-01</second>
+						<second>2.67170457248482707e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.47144086508741356e-01</second>
+						<second>-3.58440555484355328e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.68566864315456399e+00</second>
+						<second>-1.27754336132031843e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.92782036673142132e+00</second>
+						<second>1.95025217010170859e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57137,34 +57137,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.48044605467996337e+00</second>
+						<second>-1.88756249789898645e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.82452267088588060e+00</second>
+						<second>-1.32252289883767782e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>4.85931594604054384e-01</second>
+						<second>1.61161431581032200e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.79007998394638990e-01</second>
+						<second>2.23585745042004541e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.06441291034145946e-01</second>
+						<second>-2.46319048524655887e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.69776935555886421e+00</second>
+						<second>-1.25691958089829403e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14040169315113449e+00</second>
+						<second>2.14037003788386127e+00</second>
 					</item>
 				</goal_state>
-				<score>1.58325495754528789e+00</score>
+				<score>1.12431607917399867e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -57195,31 +57195,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69302807013186873e+00</second>
+						<second>-1.91730574883702753e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.80084687925616693e+00</second>
+						<second>-1.50462831131339603e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12648455461922148e+00</second>
+						<second>1.65379047724964989e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.32644525729222318e+00</second>
+						<second>4.20459206420563947e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31287724919839022e+00</second>
+						<second>1.21817202680193179e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.91158706424462843e-01</second>
+						<second>-1.41356968423901908e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87548964152909536e+00</second>
+						<second>1.70858982028590112e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57227,34 +57227,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54146591030873847e+00</second>
+						<second>-1.90452249286867903e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>-1.70587212515639175e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.24629259158364958e-01</second>
+						<second>1.50074398715173363e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.44684139822691016e+00</second>
+						<second>2.63818937548294385e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.38291662796365422e+00</second>
+						<second>-2.89383879907489316e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.04354123181146452e+00</second>
+						<second>-1.65285380444310848e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.10510314143936172e+00</second>
+						<second>2.10509473855476736e+00</second>
 					</item>
 				</goal_state>
-				<score>1.82090852553084082e+00</score>
+				<score>1.18473199757969216e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -57285,31 +57285,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.79212874292503455e+00</second>
+						<second>-1.77766226202786459e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.92496606412284860e-01</second>
+						<second>-5.49953780845725437e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.71318190447731200e+00</second>
+						<second>1.91962376428208525e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.47722336110688257e-01</second>
+						<second>2.93665289305916455e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>3.99096021371104892e-01</second>
+						<second>-2.64151900783827706e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.42002696284059660e-01</second>
+						<second>-4.30752017113473662e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19783985879488997e+00</second>
+						<second>2.24530230778481332e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57317,34 +57317,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76599754067232761e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.83269047280079970e-03</second>
+						<second>-2.56699813982316394e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.55879496176615673e+00</second>
+						<second>1.51855951103488107e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.74622699279143778e-01</second>
+						<second>2.95007190858897372e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.29864572704680570e-01</second>
+						<second>2.23174927733328088e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11735722204406757e-01</second>
+						<second>-1.27989324045928277e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.96562691171959791e+00</second>
+						<second>1.96555803126034312e+00</second>
 					</item>
 				</goal_state>
-				<score>2.22261760443252054e+00</score>
+				<score>1.41145454062805209e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -57375,31 +57375,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67909346591687791e+00</second>
+						<second>-1.87944013049928116e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.02944732388987936e-01</second>
+						<second>9.06526503861989769e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.58591236199384777e+00</second>
+						<second>1.73163533616913501e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.08245477472714047e-01</second>
+						<second>-1.22784951672225556e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.41847013319608806e-01</second>
+						<second>-7.57090782902621745e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.76295787475160537e-02</second>
+						<second>3.66303717566818857e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.84018462274060735e+00</second>
+						<second>2.19857694380479307e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57407,34 +57407,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69024088592822186e+00</second>
+						<second>-1.86176305885970073e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.32249675648927047e-02</second>
+						<second>-3.01449366295473697e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.77646637156888931e+00</second>
+						<second>1.72835465383765863e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.53281489341155508e-01</second>
+						<second>3.18641184814845824e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.24542689438383780e-01</second>
+						<second>1.78718957130188039e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.96793586381210084e-01</second>
+						<second>-1.74447593178974819e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.12704241004368244e+00</second>
+						<second>2.12704150962229122e+00</second>
 					</item>
 				</goal_state>
-				<score>1.85058777913007111e+00</score>
+				<score>1.16855141375968100e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -57465,31 +57465,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74464655436084648e+00</second>
+						<second>-1.84365423117329397e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.58802106428551483e-02</second>
+						<second>-2.58642132804804525e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.55839273722332639e+00</second>
+						<second>1.74133771600283604e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.00102572895211406e-01</second>
+						<second>3.54846666988557158e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.62897973861232526e-01</second>
+						<second>2.24464553971724656e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.44420032308462487e-01</second>
+						<second>-1.20646644301280623e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.96569910964345551e+00</second>
+						<second>2.12704592348352639e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57497,34 +57497,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.24628822490843394e+00</second>
+						<second>-1.77766226202786459e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.51153637677357144e-01</second>
+						<second>-5.49953780845725437e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.91898034040003695e+00</second>
+						<second>1.91962376428208525e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.02532876186664512e-01</second>
+						<second>2.93665289305916455e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.85962431984410803e-01</second>
+						<second>-2.64151900783827706e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70931425880790488e-01</second>
+						<second>-4.30752017113473662e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.24541234239523213e+00</second>
+						<second>2.24530230778481332e+00</second>
 					</item>
 				</goal_state>
-				<score>1.41428471295579272e+00</score>
+				<score>9.52640751916464107e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -57645,31 +57645,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69302807013186873e+00</second>
+						<second>-1.90452249286867903e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.80084687925616693e+00</second>
+						<second>-1.70587212515639175e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12648455461922148e+00</second>
+						<second>1.50074398715173363e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.32644525729222318e+00</second>
+						<second>2.63818937548294385e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.31287724919839022e+00</second>
+						<second>-2.89383879907489316e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.91158706424462843e-01</second>
+						<second>-1.65285380444310848e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.87548964152909536e+00</second>
+						<second>2.10509473855476736e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57677,34 +57677,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.78755704503224244e+00</second>
+						<second>-1.79437048719951320e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.40983277476643387e+00</second>
+						<second>-1.74523623286363283e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.51296694592313496e+00</second>
+						<second>1.49406737375718679e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.23169848335719712e-01</second>
+						<second>3.11410541009054354e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-5.34067548553156191e-01</second>
+						<second>-5.30946139261239902e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.45057298933861367e+00</second>
+						<second>-1.71226667796995624e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23616801111425101e+00</second>
+						<second>2.23623712763977922e+00</second>
 					</item>
 				</goal_state>
-				<score>1.49453310398337824e+00</score>
+				<score>9.44839222325048467e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -57735,31 +57735,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.89569321515894895e+00</second>
+						<second>1.91543396220330875e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.64819160821773622e-02</second>
+						<second>-2.71387943118568786e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.87307325652369361e-01</second>
+						<second>-9.09657384159233584e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.58174694566268759e-01</second>
+						<second>3.14149939592647298e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.63742484459578341e-01</second>
+						<second>-3.03460752997229166e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.80622707382781303e-02</second>
+						<second>-2.21318962754847165e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23354092725502440e+00</second>
+						<second>2.23325298335688327e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57767,34 +57767,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.86820585335608591e+00</second>
+						<second>1.84529394459857277e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.99559885120543828e-02</second>
+						<second>-5.21473173588000508e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.80435939785043531e-01</second>
+						<second>-8.80781357247189201e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.13334507195038359e-01</second>
+						<second>2.78561535812025030e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.65619416706035782e-01</second>
+						<second>-2.79857797770654360e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.89096095470976289e-02</second>
+						<second>-2.97202768979392268e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.19641069277522227e+00</second>
+						<second>2.19642800808119043e+00</second>
 					</item>
 				</goal_state>
-				<score>1.64920974695174438e+00</score>
+				<score>1.03261098665675066e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -57825,31 +57825,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63835038081536477e+00</second>
+						<second>-1.88532310113736656e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.44617791790042649e-01</second>
+						<second>-1.24541321851845077e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.19973239526807918e+00</second>
+						<second>1.72554943802915317e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.38904506351376877e+00</second>
+						<second>8.99884508080742301e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.41979538194622701e-01</second>
+						<second>3.41501555547702104e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.48089472495571561e+00</second>
+						<second>-8.53359524588502144e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.80299758989660330e+00</second>
+						<second>2.19777698353940520e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57857,34 +57857,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.62697928077193388e+00</second>
+						<second>-1.91966590564995143e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.22808554036886108e-01</second>
+						<second>2.57033463332335815e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.41291226084057575e+00</second>
+						<second>1.53760195366769881e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.47445485038121227e+00</second>
+						<second>2.48652405494522860e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.62866209903653281e-01</second>
+						<second>2.26680421048789688e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.40932882685638994e+00</second>
+						<second>1.46683603346302815e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.05334338872552280e+00</second>
+						<second>2.05317299488582394e+00</second>
 					</item>
 				</goal_state>
-				<score>1.88598838543338632e+00</score>
+				<score>1.26991282693311891e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -57915,31 +57915,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69024088592822186e+00</second>
+						<second>-1.87944013049928116e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.32249675648927047e-02</second>
+						<second>9.06526503861989769e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.77646637156888931e+00</second>
+						<second>1.73163533616913501e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.53281489341155508e-01</second>
+						<second>-1.22784951672225556e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.24542689438383780e-01</second>
+						<second>-7.57090782902621745e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.96793586381210084e-01</second>
+						<second>3.66303717566818857e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.12704241004368244e+00</second>
+						<second>2.19857694380479307e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -57947,34 +57947,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.79212874292503455e+00</second>
+						<second>-1.88351284793529494e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.92496606412284860e-01</second>
+						<second>-1.10496286120558715e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.71318190447731200e+00</second>
+						<second>1.72744541298596488e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.47722336110688257e-01</second>
+						<second>1.02536346705881271e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>3.99096021371104892e-01</second>
+						<second>5.04363165404059857e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.42002696284059660e-01</second>
+						<second>-6.53717692256824967e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19783985879488997e+00</second>
+						<second>2.19776768350637441e+00</second>
 					</item>
 				</goal_state>
-				<score>1.65058734548291319e+00</score>
+				<score>1.04856728946292832e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -58275,31 +58275,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.91979999999999995e+00</second>
+						<second>1.91979984351281407e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.35506134573384474e-01</second>
+						<second>-3.16659256694142299e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.47321701443612763e+00</second>
+						<second>9.12683322227841765e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.33548484254081479e-01</second>
+						<second>1.80186106113853245e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-5.45261440489975158e-01</second>
+						<second>-4.18851739221983710e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.58899827189118925e+00</second>
+						<second>-2.57965262231855452e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75067389718719335e+00</second>
+						<second>-2.19429789149678722e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -58307,34 +58307,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.89569321515894895e+00</second>
+						<second>1.89126797334327490e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.64819160821773622e-02</second>
+						<second>-9.05066265821811988e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.87307325652369361e-01</second>
+						<second>8.88925426796090656e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.58174694566268759e-01</second>
+						<second>-1.74916372789083174e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.63742484459578341e-01</second>
+						<second>1.92705850390502531e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.80622707382781303e-02</second>
+						<second>-7.53199586389064618e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23354092725502440e+00</second>
+						<second>-2.23356145602308542e+00</second>
 					</item>
 				</goal_state>
-				<score>1.54547722847656099e+00</score>
+				<score>9.67878295397519572e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -58365,31 +58365,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64397562085141113e+00</second>
+						<second>-1.91956372614706150e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.90431335606353291e-01</second>
+						<second>2.27477177112056367e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.31609272618829398e+00</second>
+						<second>1.30229037924990299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.43425117612246478e+00</second>
+						<second>-2.48535133471754155e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.48905466185118773e-01</second>
+						<second>-2.37345609484678366e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.42760024651516648e+00</second>
+						<second>1.11193526582225921e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95478867818194790e+00</second>
+						<second>1.74984045300641466e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -58397,34 +58397,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74567849187351976e+00</second>
+						<second>-1.91972015317507561e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.84281029513646466e-01</second>
+						<second>-2.49438316399876250e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.28120528764413688e+00</second>
+						<second>1.53640317859988973e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.58556877000494989e+00</second>
+						<second>-2.49578089603015973e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.17162730336124565e-01</second>
+						<second>-2.27484712287693708e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.23496900922681307e+00</second>
+						<second>-1.46545904953571837e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.05212877389038173e+00</second>
+						<second>2.05185659662847453e+00</second>
 					</item>
 				</goal_state>
-				<score>1.83670500010024140e+00</score>
+				<score>1.27183276336729989e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -58455,31 +58455,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70161036284326683e+00</second>
+						<second>-1.91829455010297778e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.07033749218828518e-03</second>
+						<second>2.60730813031981090e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.78098493310168071e+00</second>
+						<second>1.52469187803573059e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.59839466401557484e+00</second>
+						<second>-2.98236049922073365e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.63976262394450156e+00</second>
+						<second>-2.23970532538636358e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.67630116348924718e-01</second>
+						<second>1.31353998525664650e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.12629714162842287e+00</second>
+						<second>1.96937905443782646e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -58487,34 +58487,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80051413989667086e+00</second>
+						<second>-1.87944013049928116e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.69834842842290779e-01</second>
+						<second>9.06526503861989769e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.71986812406393019e+00</second>
+						<second>1.73163533616913501e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.80890980838127424e+00</second>
+						<second>-1.22784951672225556e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.76665283496820047e+00</second>
+						<second>-7.57090782902621745e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.12561780301085057e-01</second>
+						<second>3.66303717566818857e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.19863857075665026e+00</second>
+						<second>2.19857694380479307e+00</second>
 					</item>
 				</goal_state>
-				<score>1.65103478786181457e+00</score>
+				<score>1.04719191319964225e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -58815,31 +58815,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.91979984351281407e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-3.16659256694142299e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>9.12683322227841765e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.80186106113853245e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-4.18851739221983710e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.57965262231855452e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-2.19429789149678722e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -58847,34 +58847,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.81878511637749329e+00</second>
+						<second>1.91451263270107508e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.23695875169699032e-01</second>
+						<second>-2.18098247236106046e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.46439707977363764e-01</second>
+						<second>9.00664010218318545e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.42563015188256659e-01</second>
+						<second>2.79980511182041439e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-4.80643119460821555e-01</second>
+						<second>6.21284888586181999e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.45171057621394994e-01</second>
+						<second>-1.76310978525210771e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23337729625187453e+00</second>
+						<second>-2.23335612666572958e+00</second>
 					</item>
 				</goal_state>
-				<score>1.52375655115017827e+00</score>
+				<score>9.63486986356862779e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -58905,31 +58905,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70161036284326683e+00</second>
+						<second>-1.84591038154563480e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.07033749218828518e-03</second>
+						<second>2.73311672330904143e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.78098493310168071e+00</second>
+						<second>1.74150946330387657e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.59839466401557484e+00</second>
+						<second>-3.51261039806369690e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.63976262394450156e+00</second>
+						<second>-2.16142231766797588e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.67630116348924718e-01</second>
+						<second>1.36877994885647086e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.12629714162842287e+00</second>
+						<second>2.12633422995466015e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -58937,34 +58937,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.77244534066039638e+00</second>
+						<second>-1.91959758240475664e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.58479539953735281e-02</second>
+						<second>2.63578650668459202e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.56574747803144088e+00</second>
+						<second>1.52372448481979328e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.57658112755899982e+00</second>
+						<second>-2.94849039744469243e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.62471222628069967e+00</second>
+						<second>-2.20612224811658209e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.94390372407894779e-01</second>
+						<second>1.35502990288531106e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.96945581260698921e+00</second>
+						<second>1.96930170303618102e+00</second>
 					</item>
 				</goal_state>
-				<score>2.21826632113994204e+00</score>
+				<score>1.40686456977122343e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -58995,31 +58995,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61118946074284697e+00</second>
+						<second>-1.85927848136926110e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.98617843365922175e-01</second>
+						<second>3.63634056874405642e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.79868826454595032e+00</second>
+						<second>1.51934021306274536e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.36928034992117631e+00</second>
+						<second>-4.49671522543681590e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51937577331417817e+00</second>
+						<second>-3.69485442371662365e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11051965097790922e-01</second>
+						<second>2.02830256321682473e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.82329482564711554e+00</second>
+						<second>1.83807354267429246e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59027,34 +59027,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74504398299751173e+00</second>
+						<second>-1.84549999730031233e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>7.63440811853462464e-02</second>
+						<second>2.72618834858430081e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.77799598937385639e+00</second>
+						<second>1.74178003573458895e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.64396110239016524e+00</second>
+						<second>-3.52255636999881605e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.71626210839407634e+00</second>
+						<second>-2.17054258441619241e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-9.09535897830051204e-02</second>
+						<second>1.35662581583984643e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.12630334574486701e+00</second>
+						<second>2.12629508068747830e+00</second>
 					</item>
 				</goal_state>
-				<score>1.86142523524178038e+00</score>
+				<score>1.16991719645783046e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -59085,31 +59085,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72123762380160583e+00</second>
+						<second>-1.91829455010297778e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.94349126438407294e-01</second>
+						<second>2.60730813031981090e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.41814205261485693e+00</second>
+						<second>1.52469187803573059e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.70103893831332886e+00</second>
+						<second>-2.98236049922073365e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.45500599065087943e-01</second>
+						<second>-2.23970532538636358e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.16755459668353634e+00</second>
+						<second>1.31353998525664650e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19858877380077899e+00</second>
+						<second>1.96937905443782646e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59117,34 +59117,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.84245461901871166e+00</second>
+						<second>-1.77771756650459345e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.04194671261787009e+00</second>
+						<second>5.35775680852943692e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.47154084714350342e+00</second>
+						<second>1.91958303010308051e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.02006896370979705e+00</second>
+						<second>-2.92016938016123495e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.58064476397714693e-01</second>
+						<second>2.01295259335589755e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.97512776275998991e+00</second>
+						<second>4.17550886251173425e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.24598621125695619e+00</second>
+						<second>2.24584463402169510e+00</second>
 					</item>
 				</goal_state>
-				<score>1.46433250340691146e+00</score>
+				<score>9.52576891951840282e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -59265,31 +59265,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70973868526433348e+00</second>
+						<second>-1.91959855975022764e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.13465494141019230e+00</second>
+						<second>-1.28718996055976764e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.52541428617519270e+00</second>
+						<second>-1.53801849211403230e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.45360459800229069e+00</second>
+						<second>-3.77384210194172010e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.45343966798897828e+00</second>
+						<second>-2.90169555944808888e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.07375289197738866e+00</second>
+						<second>1.76533960843441839e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.09834208018544732e+00</second>
+						<second>2.01025235394594670e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59297,34 +59297,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.82360175648419687e+00</second>
+						<second>-1.81421854827414930e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.80198631524536568e+00</second>
+						<second>-1.36180723575808060e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.41685676848750575e+00</second>
+						<second>-1.44646493236973073e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.88031591604325721e+00</second>
+						<second>-2.80632664546595800e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.63110363736412101e+00</second>
+						<second>-2.62446469402513793e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.80260502746759488e+00</second>
+						<second>1.76787953121605690e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.23428557187584342e+00</second>
+						<second>2.23427596016691687e+00</second>
 					</item>
 				</goal_state>
-				<score>1.49885286916037175e+00</score>
+				<score>9.48378148399479926e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -59355,31 +59355,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78435873864266470e+00</second>
+						<second>1.85440564064621616e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.20447824058362740e-02</second>
+						<second>5.08365499559876588e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.74359929360458032e-01</second>
+						<second>1.08932988089394178e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>4.97106204185592815e-01</second>
+						<second>6.37754121882949887e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.65602674417055029e+00</second>
+						<second>-6.03347158522170579e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14110255101022950e+00</second>
+						<second>-3.03471650105087631e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14343501476974785e+00</second>
+						<second>-1.87144701088035803e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59387,34 +59387,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85333067320256317e+00</second>
+						<second>1.91979984351281407e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.30881332162781309e-02</second>
+						<second>-3.16659256694142299e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.79566541362986065e-01</second>
+						<second>9.12683322227841765e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>3.46687038246712265e-01</second>
+						<second>1.80186106113853245e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.82408828576758486e+00</second>
+						<second>-4.18851739221983710e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14149990651334399e+00</second>
+						<second>-2.57965262231855452e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.19428903574285172e+00</second>
+						<second>-2.19429789149678722e+00</second>
 					</item>
 				</goal_state>
-				<score>1.65744782516677236e+00</score>
+				<score>1.02366819644542834e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -59445,31 +59445,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61118946074284697e+00</second>
+						<second>-1.74700369797287580e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.98617843365922175e-01</second>
+						<second>3.79223978530635331e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.79868826454595032e+00</second>
+						<second>1.29163933122156438e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.36928034992117631e+00</second>
+						<second>-5.61190019507690874e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51937577331417817e+00</second>
+						<second>-5.79640947858891309e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11051965097790922e-01</second>
+						<second>2.39339844163001719e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.82329482564711554e+00</second>
+						<second>1.42475833586186851e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59477,34 +59477,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72504223409326762e+00</second>
+						<second>-1.81468950113224792e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.90157206831705589e-01</second>
+						<second>3.17920249851510350e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.45170443676102234e+00</second>
+						<second>1.41706010221304313e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.47645469444311583e+00</second>
+						<second>-5.17728455831517831e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.53093271950779153e+00</second>
+						<second>-4.76422545148714460e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.48004715393510108e-02</second>
+						<second>1.50668689505493059e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.68405799119905430e+00</second>
+						<second>1.68401477291842605e+00</second>
 					</item>
 				</goal_state>
-				<score>2.78055596923877602e+00</score>
+				<score>1.74522567438303106e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -59535,31 +59535,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74755047147047371e+00</second>
+						<second>-1.84549999730031233e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96699993615339963e+00</second>
+						<second>2.72618834858430081e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.34997560633739044e+00</second>
+						<second>1.74178003573458895e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52296230729895044e+00</second>
+						<second>-3.52255636999881605e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.55986805729571332e+00</second>
+						<second>-2.17054258441619241e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.13241144504164248e+00</second>
+						<second>1.35662581583984643e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.62079364996864350e+00</second>
+						<second>2.12629508068747830e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59567,34 +59567,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73925868115602777e+00</second>
+						<second>-1.85880551836436880e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.95930118755284877e+00</second>
+						<second>3.62806797936331527e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.57284722306790581e+00</second>
+						<second>1.51967124739942805e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.50288142124191326e+00</second>
+						<second>-4.50630113921605180e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.58147363065314694e+00</second>
+						<second>-3.70357586223715340e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14149999579694716e+00</second>
+						<second>2.01809371777050994e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.83804557518041944e+00</second>
+						<second>1.83807353227111947e+00</second>
 					</item>
 				</goal_state>
-				<score>2.53970747685909259e+00</score>
+				<score>1.59777294305439077e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -59625,31 +59625,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61118946074284697e+00</second>
+						<second>-1.75795869957996520e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.98617843365922175e-01</second>
+						<second>4.07180752978613725e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.79868826454595032e+00</second>
+						<second>1.53849932616469709e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.36928034992117631e+00</second>
+						<second>-6.15276095595160721e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51937577331417817e+00</second>
+						<second>-5.41050791640594109e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11051965097790922e-01</second>
+						<second>2.69076812305182045e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.82329482564711554e+00</second>
+						<second>1.66833892906438397e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59657,34 +59657,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67377703949013479e+00</second>
+						<second>-1.76807965068337314e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.08611511046432690e-01</second>
+						<second>3.55663889679222800e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.80046709834742580e+00</second>
+						<second>1.76077324875365915e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.48788568916233022e+00</second>
+						<second>-5.51892446878017640e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.61393424299679067e+00</second>
+						<second>-3.88110759499946167e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.76723117303994046e-02</second>
+						<second>1.95814558058999749e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.99619155314470342e+00</second>
+						<second>1.99613692255046593e+00</second>
 					</item>
 				</goal_state>
-				<score>2.21362188995722198e+00</score>
+				<score>1.38794849804453196e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -59715,31 +59715,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61118946074284697e+00</second>
+						<second>-1.91971058108923520e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.98617843365922175e-01</second>
+						<second>1.04841479273150284e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.79868826454595032e+00</second>
+						<second>1.59505597916708153e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.36928034992117631e+00</second>
+						<second>-2.70755527342188662e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51937577331417817e+00</second>
+						<second>-7.30069010165329130e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.11051965097790922e-01</second>
+						<second>9.56236052072913623e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.82329482564711554e+00</second>
+						<second>1.91961555723866617e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59747,34 +59747,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75112159522088695e+00</second>
+						<second>-1.91972338206551085e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.96564249582994921e-01</second>
+						<second>9.85930792717009119e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91924127517627552e+00</second>
+						<second>1.61676008542051797e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.63434256221412078e+00</second>
+						<second>-1.73897166827412242e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.95756546689315902e+00</second>
+						<second>1.17091013206014879e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.44994647667382559e-01</second>
+						<second>9.27108749565506596e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.10284521336635377e+00</second>
+						<second>2.10265149808131557e+00</second>
 					</item>
 				</goal_state>
-				<score>1.90730805186448604e+00</score>
+				<score>1.19896715805564033e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -59805,31 +59805,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80048301098270747e+00</second>
+						<second>-1.91979822929661315e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84968805161785999e+00</second>
+						<second>-1.78022193390661765e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84748430205586645e+00</second>
+						<second>-1.58661654475304870e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.46332549145983482e-01</second>
+						<second>-2.62278317217379930e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.98662348788025467e+00</second>
+						<second>-3.10132490982756126e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.20534791554624299e+00</second>
+						<second>1.27961282382295982e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.71109707139616929e+00</second>
+						<second>1.95452363784615391e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59837,34 +59837,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80902140764373498e+00</second>
+						<second>-1.88956939094406362e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.13647809330280403e+00</second>
+						<second>-1.82187384188769319e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.82257713740364036e+00</second>
+						<second>-1.60628106887318078e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-3.90797684858574079e-01</second>
+						<second>-2.15814563647163837e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.69108102408746075e-01</second>
+						<second>-2.89470819717448968e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>9.91534008625388763e-01</second>
+						<second>1.25750765258727792e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14114766393780620e+00</second>
+						<second>2.14110255260634430e+00</second>
 					</item>
 				</goal_state>
-				<score>1.62385540630320691e+00</score>
+				<score>1.12336141839508546e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -59895,31 +59895,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67756094309292059e+00</second>
+						<second>-1.90249239864117814e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-6.82614998071476159e-02</second>
+						<second>-1.11293954879734769e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.03509008083386855e-01</second>
+						<second>-1.37475120593888689e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.51979470162094654e-01</second>
+						<second>-3.05434296684739592e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.42928436442517137e+00</second>
+						<second>-2.74281899469910861e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.84175859876266879e+00</second>
+						<second>2.00499300264824054e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.84177391663201684e+00</second>
+						<second>2.14347953715500594e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -59927,34 +59927,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61756878853632702e+00</second>
+						<second>-1.91979986662868951e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.86699906377122261e-02</second>
+						<second>-1.39987859309283524e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.20218916113476881e-01</second>
+						<second>-1.45753328119654024e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.49393737313443298e-01</second>
+						<second>-2.24101574730646874e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.53831191808284728e+00</second>
+						<second>-2.86778853559444125e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.94199019084153379e+00</second>
+						<second>1.70647145313115045e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.09842732740091487e+00</second>
+						<second>2.09830978983747896e+00</second>
 					</item>
 				</goal_state>
-				<score>1.85598567450554541e+00</score>
+				<score>1.19708680079552668e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -59985,31 +59985,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71553405831944517e+00</second>
+						<second>-1.66154276403164358e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.81363525447515306e+00</second>
+						<second>4.04469164023093242e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.30836415022411101e+00</second>
+						<second>1.25426878329735403e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.25372812860789495e-01</second>
+						<second>-6.51147066839779409e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51524655967627986e+00</second>
+						<second>-7.01401988909576724e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.91963189805860052e-01</second>
+						<second>3.17846803577951642e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.42495041036265047e+00</second>
+						<second>1.22466064579580669e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60017,34 +60017,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72000758461120018e+00</second>
+						<second>-1.73138542618294200e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.79092171196493233e+00</second>
+						<second>3.68358932178050102e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.39742196021818588e+00</second>
+						<second>1.39164521976969779e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.47413148454069720e-01</second>
+						<second>-6.27178423613710012e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51724710219174508e+00</second>
+						<second>-6.08779370577067325e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.21674568778376352e-01</second>
+						<second>2.37254822763248108e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49540843094855869e+00</second>
+						<second>1.49537658284421338e+00</second>
 					</item>
 				</goal_state>
-				<score>3.01635550381667006e+00</score>
+				<score>1.88892743831202331e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60075,31 +60075,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65961197511560377e+00</second>
+						<second>-1.76865871518973194e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.69646067714778859e+00</second>
+						<second>3.56933044962828183e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.53031577900772309e+00</second>
+						<second>1.76043595157272859e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.31741967551904460e-01</second>
+						<second>-5.51070135576205766e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.45910974851273290e+00</second>
+						<second>-3.86943227247619759e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.94840481619833039e-01</second>
+						<second>1.96846617836950760e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44337029678732121e+00</second>
+						<second>1.99617064565379376e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60107,34 +60107,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73198821872575381e+00</second>
+						<second>-1.75795869957996520e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.77387427231482064e+00</second>
+						<second>4.07180752978613725e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.55267736899885089e+00</second>
+						<second>1.53849932616469709e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.54764526485830611e-01</second>
+						<second>-6.15276095595160721e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56582802875907356e+00</second>
+						<second>-5.41050791640594109e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.33248476775721414e-01</second>
+						<second>2.69076812305182045e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.66839468234949440e+00</second>
+						<second>1.66833892906438397e+00</second>
 					</item>
 				</goal_state>
-				<score>2.88560117858544452e+00</score>
+				<score>1.80973124141307867e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60165,31 +60165,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65961197511560377e+00</second>
+						<second>-1.84549999730031233e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.69646067714778859e+00</second>
+						<second>2.72618834858430081e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.53031577900772309e+00</second>
+						<second>1.74178003573458895e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.31741967551904460e-01</second>
+						<second>-3.52255636999881605e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.45910974851273290e+00</second>
+						<second>-2.17054258441619241e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.94840481619833039e-01</second>
+						<second>1.35662581583984643e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44337029678732121e+00</second>
+						<second>2.12629508068747830e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60197,34 +60197,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69148676600091652e+00</second>
+						<second>-1.74657088064124433e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.72504986782178538e+00</second>
+						<second>5.02356208422820916e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.76258894930419108e+00</second>
+						<second>1.72825806518057967e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.89469281811751267e-01</second>
+						<second>-6.22347643889780033e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.61785440888874588e+00</second>
+						<second>-4.53225716411970181e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.00677001556675205e-01</second>
+						<second>3.73136466024290236e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.82332949160270608e+00</second>
+						<second>1.82325666846519230e+00</second>
 					</item>
 				</goal_state>
-				<score>2.63849304395524031e+00</score>
+				<score>1.65280413628754758e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60255,31 +60255,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75171828476251035e+00</second>
+						<second>1.91895188268619310e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.97770923469155946e-01</second>
+						<second>-1.63614066927824409e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91861341112589301e+00</second>
+						<second>-1.65142534439232080e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.63522122730981945e+00</second>
+						<second>2.72420832491494869e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.95862029121322090e+00</second>
+						<second>3.02104830647267653e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.46182334507715994e-01</second>
+						<second>-1.72737568474998859e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-2.10289817575993876e+00</second>
+						<second>1.71091067947486164e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60287,34 +60287,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72852073786178773e+00</second>
+						<second>1.91882731793025085e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.72574429686349839e-01</second>
+						<second>-2.09596597711447785e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.88042130750627257e+00</second>
+						<second>-1.59773797450862642e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52241255367156381e+00</second>
+						<second>2.86754539802124198e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.82180386044420217e+00</second>
+						<second>3.06697048347689316e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.48772678965251504e-01</second>
+						<second>-2.18919105448696127e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.91966546418183226e+00</second>
+						<second>1.91955846904790617e+00</second>
 					</item>
 				</goal_state>
-				<score>2.38663141491819486e+00</score>
+				<score>1.50797448342802953e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60345,31 +60345,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77159396684215165e+00</second>
+						<second>-1.91959855975022764e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.06866063004510403e+00</second>
+						<second>-1.28718996055976764e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84760431402057868e+00</second>
+						<second>-1.53801849211403230e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46842125570228710e+00</second>
+						<second>-3.77384210194172010e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.86178733134676078e+00</second>
+						<second>-2.90169555944808888e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13831245581663687e+00</second>
+						<second>1.76533960843441839e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68223409075481634e+00</second>
+						<second>2.01025235394594670e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60377,34 +60377,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.75448154560338709e+00</second>
+						<second>-1.91979822929661315e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.10005141276530116e+00</second>
+						<second>-1.78022193390661765e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.90726415615026190e+00</second>
+						<second>-1.58661654475304870e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.56594157008385348e+00</second>
+						<second>-2.62278317217379930e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>3.05647911197432354e+00</second>
+						<second>-3.10132490982756126e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.24145473656550420e+00</second>
+						<second>1.27961282382295982e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95457673655683672e+00</second>
+						<second>1.95452363784615391e+00</second>
 					</item>
 				</goal_state>
-				<score>2.22355893659825643e+00</score>
+				<score>1.44807773575925058e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60435,31 +60435,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.78435873864266470e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.20447824058362740e-02</second>
+						<second>-1.38760210493103275e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.74359929360458032e-01</second>
+						<second>-1.59666258587359522e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>4.97106204185592815e-01</second>
+						<second>-3.87272960346193740e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.65602674417055029e+00</second>
+						<second>-3.09013511379292494e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.14110255101022950e+00</second>
+						<second>1.65782922603420246e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>2.14343501476974785e+00</second>
+						<second>1.84170789159214432e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60467,34 +60467,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.57494022683167900e+00</second>
+						<second>-1.91979732895855304e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-8.12253977106517783e-02</second>
+						<second>-1.52999278244622117e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-7.58206752544709039e-01</second>
+						<second>-1.57907463357606148e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.82877438931468106e-01</second>
+						<second>-3.13095264150731467e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.42425104320007545e+00</second>
+						<second>-3.06981523930956257e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.78332158770567428e+00</second>
+						<second>1.52459940767053781e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.91968242144955559e+00</second>
+						<second>1.91962271522387229e+00</second>
 					</item>
 				</goal_state>
-				<score>2.30666643850350983e+00</score>
+				<score>1.50184639529350156e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60525,31 +60525,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61579486727849186e+00</second>
+						<second>-1.61181417444521946e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.54850425699016947e-01</second>
+						<second>5.69588366801066170e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.17070704193088182e+00</second>
+						<second>1.44571238207649810e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.42353665347439007e+00</second>
+						<second>-8.26371626033692852e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.40356964528046957e+00</second>
+						<second>-7.91194832551771698e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.55463653309889954e-01</second>
+						<second>6.49385492738040138e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.20734282783182345e+00</second>
+						<second>1.07752470756645602e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60557,34 +60557,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52909997632289874e+00</second>
+						<second>-1.57427415437525853e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.64346866375074574e-01</second>
+						<second>4.65423345427814050e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.19465415074969039e+00</second>
+						<second>1.17191272785316647e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.33006631643473661e+00</second>
+						<second>-6.95530754260900830e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.27880100231522631e+00</second>
+						<second>-8.06639339970961156e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.03968839250120892e-01</second>
+						<second>4.52095298289798442e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.50071081065153922e-01</second>
+						<second>9.50131703263129901e-01</second>
 					</item>
 				</goal_state>
-				<score>2.65024481999949568e+00</score>
+				<score>1.65970249422889488e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60615,31 +60615,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65961197511560377e+00</second>
+						<second>-1.66154276403164358e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.69646067714778859e+00</second>
+						<second>4.04469164023093242e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.53031577900772309e+00</second>
+						<second>1.25426878329735403e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.31741967551904460e-01</second>
+						<second>-6.51147066839779409e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.45910974851273290e+00</second>
+						<second>-7.01401988909576724e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.94840481619833039e-01</second>
+						<second>3.17846803577951642e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44337029678732121e+00</second>
+						<second>1.22466064579580669e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60647,34 +60647,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.63871456235047597e+00</second>
+						<second>-1.64964947463161549e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.71909572797862786e+00</second>
+						<second>4.42561151243346385e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33310262914724298e+00</second>
+						<second>1.32698325678634621e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.08814236947989729e-01</second>
+						<second>-6.86366971689100436e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.40292323607469926e+00</second>
+						<second>-7.25063010050958301e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.75237167160647755e-01</second>
+						<second>3.88406001427574643e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22684857501630362e+00</second>
+						<second>1.22678786556953012e+00</second>
 					</item>
 				</goal_state>
-				<score>3.06641290989440307e+00</score>
+				<score>1.91941655641228226e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60705,31 +60705,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59635108789639024e+00</second>
+						<second>-1.61181417444521946e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.60275698183901572e+00</second>
+						<second>5.69588366801066170e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.45507801800487213e+00</second>
+						<second>1.44571238207649810e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.58229141339209467e-01</second>
+						<second>-8.26371626033692852e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.33537173421226196e+00</second>
+						<second>-7.91194832551771698e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.35957391415943984e-01</second>
+						<second>6.49385492738040138e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.07746423944436520e+00</second>
+						<second>1.07752470756645602e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60737,34 +60737,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65931524532564079e+00</second>
+						<second>-1.67766065482505122e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.69718534677328581e+00</second>
+						<second>4.74643295352331962e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.53047279703550165e+00</second>
+						<second>1.51986392209254562e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.32225420554768691e-01</second>
+						<second>-7.02471753943437971e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.45862291803228850e+00</second>
+						<second>-6.61502239722142837e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.94338855913131836e-01</second>
+						<second>4.15480247627838362e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44335796056823518e+00</second>
+						<second>1.44335792370698712e+00</second>
 					</item>
 				</goal_state>
-				<score>3.16789136235634938e+00</score>
+				<score>1.98541746616870823e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60795,31 +60795,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72852073786178773e+00</second>
+						<second>-1.72727793820390896e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.72574429686349839e-01</second>
+						<second>6.70505647361587687e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.88042130750627257e+00</second>
+						<second>1.88156204279066808e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52241255367156381e+00</second>
+						<second>-6.20629081872138055e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.82180386044420217e+00</second>
+						<second>-3.21295791925764240e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.48772678965251504e-01</second>
+						<second>5.47009279691446415e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.91966546418183226e+00</second>
+						<second>1.91966541468305296e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60827,34 +60827,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73942180547431557e+00</second>
+						<second>-1.73836751260697508e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.56111198208569224e-01</second>
+						<second>6.54244799826771861e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.65379993408653525e+00</second>
+						<second>1.65474431822302726e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.51989583244975890e+00</second>
+						<second>-6.23444462917959741e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.62942176864082855e+00</second>
+						<second>-5.13404553382337592e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.78433977557595402e-01</second>
+						<second>5.76945033302778576e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.60017158372046042e+00</second>
+						<second>1.60017110655731165e+00</second>
 					</item>
 				</goal_state>
-				<score>3.06266856717553715e+00</score>
+				<score>1.91827549872175818e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60885,31 +60885,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71002992049489233e+00</second>
+						<second>-1.91969798646429135e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.08732051146694753e+00</second>
+						<second>1.52577029312792178e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.91921652080973271e+00</second>
+						<second>1.53930803431679819e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.26610703976341110e+00</second>
+						<second>-3.59730457042042095e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.74310944076803898e+00</second>
+						<second>-5.12567485633063868e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.01040111925714582e+00</second>
+						<second>-8.75652013025575826e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44941722187336164e+00</second>
+						<second>1.07997444556590083e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -60917,34 +60917,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77095701700091990e+00</second>
+						<second>-1.87193678642939254e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.28027467059074906e+00</second>
+						<second>1.06376185800336565e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.75516559145398499e+00</second>
+						<second>1.60797523793906127e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.53666287599342288e+00</second>
+						<second>-3.99450558740367834e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.76021057383044832e+00</second>
+						<second>-2.78439938017165600e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.36205101850705379e+00</second>
+						<second>9.68495528507492986e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68112457478936639e+00</second>
+						<second>1.68127057411004488e+00</second>
 					</item>
 				</goal_state>
-				<score>2.87498980973320117e+00</score>
+				<score>1.84144619476834637e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -60975,31 +60975,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.91895188268619310e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.63614066927824409e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.65142534439232080e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>0.00000000000000000e+00</second>
+						<second>2.72420832491494869e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>0.00000000000000000e+00</second>
+						<second>3.02104830647267653e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>0.00000000000000000e+00</second>
+						<second>-1.72737568474998859e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>0.00000000000000000e+00</second>
+						<second>1.71091067947486164e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -61007,34 +61007,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77159396684215165e+00</second>
+						<second>1.91979594334492543e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.06866063004510403e+00</second>
+						<second>-1.78636222175544113e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84760431402057868e+00</second>
+						<second>-1.61257331852934671e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46842125570228710e+00</second>
+						<second>2.76219369558678540e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.86178733134676078e+00</second>
+						<second>2.95001338859294204e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13831245581663687e+00</second>
+						<second>-1.87548773645784861e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68223409075481634e+00</second>
+						<second>1.68206047407761439e+00</second>
 					</item>
 				</goal_state>
-				<score>2.77506490340637679e+00</score>
+				<score>1.84136439155051845e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -61065,31 +61065,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.84582246476757161e+00</second>
+						<second>1.91971078423910901e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.72395355011903684e+00</second>
+						<second>-1.69326286021334993e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.83810554920398217e+00</second>
+						<second>-1.64865919516368464e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.29344276703311700e-01</second>
+						<second>2.66318434326514009e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.92071990593650588e+00</second>
+						<second>2.83434441791442060e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.25010227757585413e+00</second>
+						<second>-1.74324732117652270e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49968478738721411e+00</second>
+						<second>1.44910393801641724e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -61097,34 +61097,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.80048301098270747e+00</second>
+						<second>1.91895188268619310e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84968805161785999e+00</second>
+						<second>-1.63614066927824409e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84748430205586645e+00</second>
+						<second>-1.65142534439232080e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.46332549145983482e-01</second>
+						<second>2.72420832491494869e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.98662348788025467e+00</second>
+						<second>3.02104830647267653e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.20534791554624299e+00</second>
+						<second>-1.72737568474998859e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.71109707139616929e+00</second>
+						<second>1.71091067947486164e+00</second>
 					</item>
 				</goal_state>
-				<score>2.71467833239565692e+00</score>
+				<score>1.79616345438926350e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -61245,31 +61245,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.51230713358653635e+00</second>
+						<second>-1.61181417444521946e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.26780305342933652e-01</second>
+						<second>5.69588366801066170e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.27372521576882147e+00</second>
+						<second>1.44571238207649810e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.23502228751209220e+00</second>
+						<second>-8.26371626033692852e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.22909502854544561e+00</second>
+						<second>-7.91194832551771698e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.78640024750708859e-01</second>
+						<second>6.49385492738040138e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.50122544749484343e-01</second>
+						<second>1.07752470756645602e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -61277,34 +61277,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39759981785532950e+00</second>
+						<second>-1.42032772125166429e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.45714865229058010e-01</second>
+						<second>5.61921043199846038e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.01346146480753441e+00</second>
+						<second>1.00093078929475099e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.23036085323402533e+00</second>
+						<second>-7.84921005013061612e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.12308627895328339e+00</second>
+						<second>-9.91596122087781584e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.72250877136270408e-01</second>
+						<second>6.92585082007715180e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.26405460887725074e-01</second>
+						<second>4.26396868705470444e-01</second>
 					</item>
 				</goal_state>
-				<score>1.31157476336570111e+00</score>
+				<score>8.38144208527186324e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -61335,31 +61335,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52636168054638977e+00</second>
+						<second>-1.66154276403164358e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.32329695290015437e-01</second>
+						<second>4.04469164023093242e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12358425593804667e+00</second>
+						<second>1.25426878329735403e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.34653545758875692e+00</second>
+						<second>-6.51147066839779409e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29248955419028677e+00</second>
+						<second>-7.01401988909576724e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.39835673713761055e-01</second>
+						<second>3.17846803577951642e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.36033705620898937e-01</second>
+						<second>1.22466064579580669e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -61367,34 +61367,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.51230713358653635e+00</second>
+						<second>-1.55685539083927593e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.26780305342933652e-01</second>
+						<second>5.36345088352290333e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.27372521576882147e+00</second>
+						<second>1.25011603707640484e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.23502228751209220e+00</second>
+						<second>-7.88136721147076447e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.22909502854544561e+00</second>
+						<second>-8.65176193572423480e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.78640024750708859e-01</second>
+						<second>6.18113043249194360e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.50122544749484343e-01</second>
+						<second>8.49947367957345490e-01</second>
 					</item>
 				</goal_state>
-				<score>2.53630813439910208e+00</score>
+				<score>1.63960347079895596e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -61425,31 +61425,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61581092686358518e+00</second>
+						<second>-1.66154276403164358e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.55287638504021830e+00</second>
+						<second>4.04469164023093242e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62784505968444826e+00</second>
+						<second>1.25426878329735403e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-9.30812516726647665e-01</second>
+						<second>-6.51147066839779409e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.38537965705523103e+00</second>
+						<second>-7.01401988909576724e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.30283731290217619e-01</second>
+						<second>3.17846803577951642e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.18875762740648838e+00</second>
+						<second>1.22466064579580669e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -61457,34 +61457,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59635108789639024e+00</second>
+						<second>-1.60627343087454677e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.60275698183901572e+00</second>
+						<second>5.58602964796664381e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.45507801800487213e+00</second>
+						<second>1.44917209155144966e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.58229141339209467e-01</second>
+						<second>-8.38001744225786993e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.33537173421226196e+00</second>
+						<second>-7.96555759595513058e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.35957391415943984e-01</second>
+						<second>6.44622624564070268e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.07746423944436520e+00</second>
+						<second>1.07748586291641257e+00</second>
 					</item>
 				</goal_state>
-				<score>3.02662676986478862e+00</score>
+				<score>1.95861775605158966e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -61515,31 +61515,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.79690243135123939e+00</second>
+						<second>-1.63244507052330401e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.99895877951538581e+00</second>
+						<second>6.12575709423208048e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.59349018850455471e+00</second>
+						<second>1.43203049514248937e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.61671754468278306e-01</second>
+						<second>-7.82091948850927476e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.49004642236794016e+00</second>
+						<second>-7.70649471127811792e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.00722778006336489e+00</second>
+						<second>6.69275584394438683e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.35672834107230789e-01</second>
+						<second>1.07751298874340384e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -61547,34 +61547,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65822714549594807e+00</second>
+						<second>-1.65722166504994872e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.47342485774807885e+00</second>
+						<second>6.66205748220882743e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.60039573211089459e+00</second>
+						<second>1.60110511329429084e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-8.56036573889997765e-01</second>
+						<second>-8.58069005088566317e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.42340860311383333e+00</second>
+						<second>-7.19152535442778129e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.64532141877542260e-01</second>
+						<second>7.63646992544041114e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.18894872780715799e+00</second>
+						<second>1.18882215033215854e+00</second>
 					</item>
 				</goal_state>
-				<score>3.29101159047427227e+00</score>
+				<score>2.06961017157769156e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -61605,31 +61605,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.77159396684215165e+00</second>
+						<second>-1.91969798646429135e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.06866063004510403e+00</second>
+						<second>1.52577029312792178e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.84760431402057868e+00</second>
+						<second>1.53930803431679819e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46842125570228710e+00</second>
+						<second>-3.59730457042042095e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.86178733134676078e+00</second>
+						<second>-5.12567485633063868e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.13831245581663687e+00</second>
+						<second>-8.75652013025575826e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.68223409075481634e+00</second>
+						<second>1.07997444556590083e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -61637,34 +61637,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.80997196953296724e+00</second>
+						<second>-1.78419624947383970e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.13396736033743251e+00</second>
+						<second>9.53225472434185872e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.62934275283419061e+00</second>
+						<second>1.65685949960323842e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.43913050759826389e+00</second>
+						<second>-7.58250238514346253e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.57578701736583193e+00</second>
+						<second>-5.84318285410919347e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.10567519364315547e+00</second>
+						<second>1.00651460850489571e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22484651217601614e+00</second>
+						<second>1.22481365901583228e+00</second>
 					</item>
 				</goal_state>
-				<score>3.17211517225196893e+00</score>
+				<score>2.09364308038469032e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -61695,31 +61695,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.82941622077009791e+00</second>
+						<second>1.91971078423910901e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.88088986423977245e+00</second>
+						<second>-1.69326286021334993e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.78605790741710413e+00</second>
+						<second>-1.64865919516368464e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.83761554474239697e-01</second>
+						<second>2.66318434326514009e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.80387166321470271e+00</second>
+						<second>2.83434441791442060e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.25456778980536288e+00</second>
+						<second>-1.74324732117652270e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44918559034931538e+00</second>
+						<second>1.44910393801641724e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -61727,34 +61727,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.85615876821629033e+00</second>
+						<second>1.91979820368238396e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.94799669740892334e+00</second>
+						<second>-1.79482238013828677e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.68646863029297123e+00</second>
+						<second>-1.58699998485491589e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.35376135257657126e-01</second>
+						<second>2.67787713305804864e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.69573122035149648e+00</second>
+						<second>2.72650465092621230e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.19406712922579050e+00</second>
+						<second>-1.83864765747976411e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.32815184007931286e+00</second>
+						<second>1.32797743382128020e+00</second>
 					</item>
 				</goal_state>
-				<score>3.25819673487709194e+00</score>
+				<score>2.09606504715738273e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -62325,31 +62325,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60544055699404176e+00</second>
+						<second>-1.74607919774644826e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.47705731410902530e+00</second>
+						<second>9.98799827935420215e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.61232943720656929e+00</second>
+						<second>1.65047892423963249e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.06088088720692664e+00</second>
+						<second>-8.10277060590462228e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29568149074095595e+00</second>
+						<second>-6.82949695314550631e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.08014742313546153e+00</second>
+						<second>-1.06445215219560674e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.85891633684039248e-01</second>
+						<second>9.35130022634869884e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -62357,34 +62357,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54923670126351598e+00</second>
+						<second>-1.53595540433817690e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.49836774517795090e+00</second>
+						<second>5.87278524009488323e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.41120415184779691e+00</second>
+						<second>1.41873900582391355e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.03709302955597948e+00</second>
+						<second>-1.09436470554444543e+00</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.18077708524601421e+00</second>
+						<second>-9.71513750755293781e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.11410159141804610e+00</second>
+						<second>1.10696943596985520e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.79005666799255658e-01</second>
+						<second>4.78900231500105023e-01</second>
 					</item>
 				</goal_state>
-				<score>1.68196193634369906e+00</score>
+				<score>1.15349627410349903e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -62415,31 +62415,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54923670126351598e+00</second>
+						<second>-1.56437694398859461e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.49836774517795090e+00</second>
+						<second>7.10008867998870086e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.41120415184779691e+00</second>
+						<second>1.40149889790750271e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.03709302955597948e+00</second>
+						<second>-9.69366015251636237e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.18077708524601421e+00</second>
+						<second>-9.48726482462997844e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.11410159141804610e+00</second>
+						<second>1.12400837738553983e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.79005666799255658e-01</second>
+						<second>4.78662455768909090e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -62447,34 +62447,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60553799279419107e+00</second>
+						<second>-1.63087443996577219e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.47680080436684502e+00</second>
+						<second>7.32642053730761078e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.61227029635699903e+00</second>
+						<second>1.59595235845316585e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-1.06063164732243509e+00</second>
+						<second>-9.94464808720517901e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.29575687813833662e+00</second>
+						<second>-8.26399506822615537e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.08020164313792755e+00</second>
+						<second>1.09552046246619628e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.85891741628480966e-01</second>
+						<second>7.85889506309931929e-01</second>
 					</item>
 				</goal_state>
-				<score>2.47626754124628601e+00</score>
+				<score>1.74420299000635493e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -64305,31 +64305,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.37868660879675220e+00</second>
+						<second>-1.63469438704071224e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.40007595017355890e-01</second>
+						<second>2.86374081108966827e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.02958257629769623e+00</second>
+						<second>-1.16547871099548850e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>1.02398841271607077e+00</second>
+						<second>6.81807224991277216e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.04055737191193343e+00</second>
+						<second>-2.42983401325856363e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-6.50208787367546726e-01</second>
+						<second>-1.68808488371877924e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.41354093869825770e-01</second>
+						<second>1.21464747888233204e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -64337,34 +64337,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36223008327579698e+00</second>
+						<second>-1.39696051528680343e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.08419268174871974e-01</second>
+						<second>2.67964961327319795e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.74703776989244264e-01</second>
+						<second>-9.60317916222787837e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.87858018607627009e-01</second>
+						<second>8.16666052845461676e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.02832293142760278e+00</second>
+						<second>-2.15583662279825106e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.69616581662928834e-01</second>
+						<second>-5.97479933779544004e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.56093307037337636e-01</second>
+						<second>4.55905456003524501e-01</second>
 					</item>
 				</goal_state>
-				<score>1.35710861655873294e+00</score>
+				<score>8.51138482470655960e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -64665,31 +64665,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36223008327579698e+00</second>
+						<second>-1.63469438704071224e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-3.08419268174871974e-01</second>
+						<second>2.86374081108966827e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.74703776989244264e-01</second>
+						<second>-1.16547871099548850e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.87858018607627009e-01</second>
+						<second>6.81807224991277216e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>1.02832293142760278e+00</second>
+						<second>-2.42983401325856363e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-5.69616581662928834e-01</second>
+						<second>-1.68808488371877924e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.56093307037337636e-01</second>
+						<second>1.21464747888233204e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -64697,34 +64697,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.36127935133649247e+00</second>
+						<second>-1.39761463040118250e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.64227526355316933e-01</second>
+						<second>2.72312379906255142e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.61608411318528389e-01</second>
+						<second>-8.47744247055524647e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>9.46207584370517996e-01</second>
+						<second>7.65985261006430385e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>9.90006585311990484e-01</second>
+						<second>-2.20304971580200881e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-4.37035489445765757e-01</second>
+						<second>-4.69253926750569927e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>4.69257740756825914e-01</second>
+						<second>4.69105741100556473e-01</second>
 					</item>
 				</goal_state>
-				<score>1.25329986032945406e+00</score>
+				<score>7.84421114079253134e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -64755,31 +64755,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.48223585256735890e+00</second>
+						<second>-1.63469438704071224e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84179320912122663e-01</second>
+						<second>2.86374081108966827e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.44683694354007453e-01</second>
+						<second>-1.16547871099548850e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.23145303056740496e-01</second>
+						<second>6.81807224991277216e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.53729718868275422e-01</second>
+						<second>-2.42983401325856363e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.73153370550878538e-01</second>
+						<second>-1.68808488371877924e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.52569659044851380e-01</second>
+						<second>1.21464747888233204e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -64787,34 +64787,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.49134999512002620e+00</second>
+						<second>-1.54881464213624986e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.54309693019022454e-01</second>
+						<second>2.77243701249157937e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.15053502511844430e+00</second>
+						<second>-1.12978920440027464e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.87098605604662915e-01</second>
+						<second>7.51575910316958140e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.94498875682213979e-01</second>
+						<second>-2.31749752760188032e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.02843607090383937e-01</second>
+						<second>-3.56735655749460812e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.53577558907366618e-01</second>
+						<second>9.53301428766651471e-01</second>
 					</item>
 				</goal_state>
-				<score>2.56203644999462776e+00</score>
+				<score>1.60912425452543889e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -64845,31 +64845,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63789170127869665e+00</second>
+						<second>-1.53487027819103217e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.72265959196362317e+00</second>
+						<second>2.84382900645600678e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33038523130822028e+00</second>
+						<second>-9.28763568556694286e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.43139997145057940e+00</second>
+						<second>6.70847498796880992e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.40184537534954812e+00</second>
+						<second>-2.36773896748096790e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.77026608971712918e+00</second>
+						<second>-2.30161227648038674e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22576411079849779e+00</second>
+						<second>8.52376222440394793e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -64877,34 +64877,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64888339505604864e+00</second>
+						<second>-1.62610793158069766e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.75682184723469170e+00</second>
+						<second>2.79645804386336350e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.26193275250488424e+00</second>
+						<second>-1.27272395118739712e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.46315423693026769e+00</second>
+						<second>7.25106496266384903e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.42313967424857468e+00</second>
+						<second>-2.39357521213660407e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.83605072481505216e+00</second>
+						<second>-2.78480759404820477e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.22314063803218565e+00</second>
+						<second>1.22318562693825195e+00</second>
 					</item>
 				</goal_state>
-				<score>2.96806835776201261e+00</score>
+				<score>1.86338219536844568e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -65115,31 +65115,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.49132019866036036e+00</second>
+						<second>-1.63469438704071224e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.54253477600731304e-01</second>
+						<second>2.86374081108966827e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.15054332515347069e+00</second>
+						<second>-1.16547871099548850e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.87164314367234197e-01</second>
+						<second>6.81807224991277216e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.94533768256409623e-01</second>
+						<second>-2.42983401325856363e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.02819284496538832e-01</second>
+						<second>-1.68808488371877924e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>9.53577580936474156e-01</second>
+						<second>1.21464747888233204e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -65147,34 +65147,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.48223585256735890e+00</second>
+						<second>-1.53282995117727427e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84179320912122663e-01</second>
+						<second>2.84867415093041609e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.44683694354007453e-01</second>
+						<second>-9.29578824554748273e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.23145303056740496e-01</second>
+						<second>6.77294951268613166e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.53729718868275422e-01</second>
+						<second>-2.36439005506468769e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.73153370550878538e-01</second>
+						<second>-2.27585921001991043e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.52569659044851380e-01</second>
+						<second>8.52406295573170714e-01</second>
 					</item>
 				</goal_state>
-				<score>2.09137228757285731e+00</score>
+				<score>1.30989453827603325e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -65205,31 +65205,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63462043278501756e+00</second>
+						<second>-1.61421576840574876e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.92820636833935977e+00</second>
+						<second>2.96644994442255250e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.26981424305140300e-01</second>
+						<second>-9.33198166852003297e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.59603081813040903e+00</second>
+						<second>6.05853911425026870e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.52703345022131876e+00</second>
+						<second>-2.48776422750152104e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.05732533892347869e+00</second>
+						<second>-5.28038063367635285e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.04807288272560784e+00</second>
+						<second>1.04811496802120763e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -65237,34 +65237,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.66110631140187404e+00</second>
+						<second>-1.63517516367085114e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81899582271532356e+00</second>
+						<second>2.86295353934909347e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.15444144382355574e+00</second>
+						<second>-1.16529868144984960e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51833261420991583e+00</second>
+						<second>6.80789577201753704e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.46862437408077451e+00</second>
+						<second>-2.43051735772402777e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.93814903269952898e+00</second>
+						<second>-1.69402941344964170e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.21459551553429690e+00</second>
+						<second>1.21464608073678759e+00</second>
 					</item>
 				</goal_state>
-				<score>2.81168540436485559e+00</score>
+				<score>1.76367748075433289e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -65295,31 +65295,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72782590736430341e+00</second>
+						<second>-1.64455156868726138e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.78078938911414575e+00</second>
+						<second>2.76435696538975417e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.55475685350429371e+00</second>
+						<second>-1.26413957774367258e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48050623938856640e+00</second>
+						<second>6.87522821501096226e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.56036164926105014e+00</second>
+						<second>-2.41751701516645845e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.91482966344897543e+00</second>
+						<second>-3.00349805243267154e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.66894884077853378e+00</second>
+						<second>1.22318796370944782e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -65327,34 +65327,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.71482009913695577e+00</second>
+						<second>-1.70801616709973425e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81459401948418853e+00</second>
+						<second>2.82531690701674121e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.30908753455160354e+00</second>
+						<second>-1.31216418515324373e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51453723303178345e+00</second>
+						<second>6.40567936170013619e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.51405946635998445e+00</second>
+						<second>-2.50408886335120640e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.95041106789084662e+00</second>
+						<second>-1.81945418231694744e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.42503712709038943e+00</second>
+						<second>1.42477237248124178e+00</second>
 					</item>
 				</goal_state>
-				<score>2.98209612723430562e+00</score>
+				<score>1.86817207498902571e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -65475,31 +65475,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.48223585256735890e+00</second>
+						<second>-1.53487027819103217e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.84179320912122663e-01</second>
+						<second>2.84382900645600678e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>9.44683694354007453e-01</second>
+						<second>-9.28763568556694286e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>8.23145303056740496e-01</second>
+						<second>6.70847498796880992e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>8.53729718868275422e-01</second>
+						<second>-2.36773896748096790e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.73153370550878538e-01</second>
+						<second>-2.30161227648038674e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.52569659044851380e-01</second>
+						<second>8.52376222440394793e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -65507,34 +65507,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.41189264396965908e+00</second>
+						<second>-1.44546282598930942e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.05468198008550576e-01</second>
+						<second>2.92625658559468693e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>6.70883652212576176e-01</second>
+						<second>-6.63651538020732512e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>7.71716109550342422e-01</second>
+						<second>6.13293870892164805e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.94461038894873739e-01</second>
+						<second>-2.41899298273738106e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.19296869967734878e-01</second>
+						<second>-1.60103558018533154e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>5.74910815261078900e-01</second>
+						<second>5.74881738770860240e-01</second>
 					</item>
 				</goal_state>
-				<score>1.17856655723610326e+00</score>
+				<score>7.37158394892709068e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -65565,31 +65565,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.66066501829163360e+00</second>
+						<second>-1.63469438704071224e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.81983341164286960e+00</second>
+						<second>2.86374081108966827e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.15459929940201778e+00</second>
+						<second>-1.16547871099548850e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51672498306495340e+00</second>
+						<second>6.81807224991277216e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.46768754438344295e+00</second>
+						<second>-2.42983401325856363e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.93849379968647062e+00</second>
+						<second>-1.68808488371877924e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.21428875815116966e+00</second>
+						<second>1.21464747888233204e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -65597,34 +65597,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.63462043278501756e+00</second>
+						<second>-1.61421576840574876e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.92820636833935977e+00</second>
+						<second>2.96644994442255250e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.26981424305140300e-01</second>
+						<second>-9.33198166852003297e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.59603081813040903e+00</second>
+						<second>6.05853911425026870e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.52703345022131876e+00</second>
+						<second>-2.48776422750152104e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.05732533892347869e+00</second>
+						<second>-5.28038063367635285e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.04807288272560784e+00</second>
+						<second>1.04811496802120763e+00</second>
 					</item>
 				</goal_state>
-				<score>2.32029742004960582e+00</score>
+				<score>1.45567057934103489e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -65655,31 +65655,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73110566756165651e+00</second>
+						<second>-1.78579569468600630e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.77635814861694863e+00</second>
+						<second>2.86551241539707169e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.39449278697979873e+00</second>
+						<second>-1.43050612254755904e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.51253552210635211e+00</second>
+						<second>5.70577465592726263e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.53253797949373061e+00</second>
+						<second>-2.61903773062704737e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.90805007464500065e+00</second>
+						<second>-1.04049836806926560e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49988536014197904e+00</second>
+						<second>1.68227919273040283e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -65687,34 +65687,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74137046169233978e+00</second>
+						<second>-1.73998571896557497e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.90482152295904550e+00</second>
+						<second>2.90716342744939693e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.14552536569234165e+00</second>
+						<second>-1.14606175184513992e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.61794406177421202e+00</second>
+						<second>5.27110581087996355e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.59397938466180022e+00</second>
+						<second>-2.59135457615976295e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.06511774149403760e+00</second>
+						<second>-7.40514422077174495e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.37508332433671066e+00</second>
+						<second>1.37504355428280856e+00</second>
 					</item>
 				</goal_state>
-				<score>2.79910347740579413e+00</score>
+				<score>1.75296002640899617e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -65745,31 +65745,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73078968255012589e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>7.47439562092142625e-03</second>
+						<second>3.22215607485255157e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13176583513988849e+00</second>
+						<second>1.29119479996841413e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.00915333414596575e-01</second>
+						<second>2.73497267924299459e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.68593273285678102e-01</second>
+						<second>2.45243360007955297e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.07673001590367362e-01</second>
+						<second>1.63132697745417138e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49766195620005260e+00</second>
+						<second>1.80273501994564977e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -65777,34 +65777,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.69962806469953653e+00</second>
+						<second>-1.81641115086587002e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.12469469834475658e-01</second>
+						<second>-2.71997797765203941e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.36263387108325040e+00</second>
+						<second>1.32821739491945268e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.91514445066621630e-01</second>
+						<second>4.90359367093939569e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.49379348199519368e-01</second>
+						<second>4.69573756661680553e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>7.47141003672900511e-02</second>
+						<second>-1.01762524497854556e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.62546111558521700e+00</second>
+						<second>1.62518737407227754e+00</second>
 					</item>
 				</goal_state>
-				<score>2.78357441156326457e+00</score>
+				<score>1.75574348608066727e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -65835,31 +65835,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75710114345983048e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>9.78689810643983138e-03</second>
+						<second>-1.75035080538460758e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.55873961545851691e+00</second>
+						<second>1.42795588243118177e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.85552513694617471e-01</second>
+						<second>3.05647721498500002e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.43777858502480393e-01</second>
+						<second>2.60795456632877676e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.25562014398732524e-01</second>
+						<second>-3.68506029823346681e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.96562695644893926e+00</second>
+						<second>1.88855792938110034e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -65867,34 +65867,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72571976044136144e+00</second>
+						<second>-1.88193652346536133e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-6.58020683904094184e-02</second>
+						<second>-2.89222033805306367e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.46594022777492938e+00</second>
+						<second>1.41923921836792299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.62602685770425359e-01</second>
+						<second>3.97149059180784747e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.09167610231513001e-01</second>
+						<second>3.48192191339474433e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.41613173692224009e-01</second>
+						<second>-1.30468144116547446e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79453085865062878e+00</second>
+						<second>1.79454036034393805e+00</second>
 					</item>
 				</goal_state>
-				<score>2.56969598985473446e+00</score>
+				<score>1.62266254468867999e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -66015,31 +66015,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54366507048984825e+00</second>
+						<second>-1.61392621855045149e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.56105009648136617e-01</second>
+						<second>2.96700000000000008e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>6.50071567907060555e-01</second>
+						<second>-9.33186066916094403e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.60510964856758997e-01</second>
+						<second>6.07191686961003341e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.52449647592566340e-01</second>
+						<second>-2.48697901515150832e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.84744376758726347e-01</second>
+						<second>-5.25874804848252830e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.40257492939055717e-01</second>
+						<second>1.04781494793339247e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66047,34 +66047,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.50720012175455964e+00</second>
+						<second>-1.55894905759498870e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.80543303923708985e-02</second>
+						<second>2.96700000000000008e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>6.76852059960830088e-01</second>
+						<second>-6.66991581680690060e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.06296680019806633e-01</second>
+						<second>3.49548592783498091e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.00703847118595369e-01</second>
+						<second>-2.69480018426478241e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.68336331601377008e-02</second>
+						<second>-7.32025269801875322e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.55794078425478966e-01</second>
+						<second>7.55554471920434012e-01</second>
 					</item>
 				</goal_state>
-				<score>1.46960150185848848e+00</score>
+				<score>9.20779565605111538e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -66105,31 +66105,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.55905707948953820e+00</second>
+						<second>-1.53487027819103217e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96700000000000008e+00</second>
+						<second>2.84382900645600678e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.66626876561165815e-01</second>
+						<second>-9.28763568556694286e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.79161999085778900e+00</second>
+						<second>6.70847498796880992e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.69447138737248126e+00</second>
+						<second>-2.36773896748096790e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.06831516715105490e+00</second>
+						<second>-2.30161227648038674e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>7.54790739581616799e-01</second>
+						<second>8.52376222440394793e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66137,7 +66137,7 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74298356744245009e+00</second>
+						<second>-1.74270243105132927e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
@@ -66145,26 +66145,26 @@
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.06206470043442125e-01</second>
+						<second>-9.06498064330003683e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.84705709009621799e+00</second>
+						<second>2.94159325483515754e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>-2.78494963219267921e+00</second>
+						<second>-2.78521393740256151e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.08647807770610738e+00</second>
+						<second>-5.54643383878153928e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.18002683311874246e+00</second>
+						<second>1.18058378151725263e+00</second>
 					</item>
 				</goal_state>
-				<score>2.40061118769434723e+00</score>
+				<score>1.50497654791904190e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -66195,31 +66195,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68979172565108571e+00</second>
+						<second>-1.88193652346536133e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.40661178458892450e-01</second>
+						<second>-2.89222033805306367e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.79794719064283748e-01</second>
+						<second>1.41923921836792299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.36820759487802390e-01</second>
+						<second>3.97149059180784747e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.61304873203194576e-01</second>
+						<second>3.48192191339474433e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.79200750617774440e-01</second>
+						<second>-1.30468144116547446e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.23907407792497670e+00</second>
+						<second>1.79454036034393805e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66227,34 +66227,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73146196099327043e+00</second>
+						<second>-1.84628260113893106e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>6.66459655639824785e-03</second>
+						<second>-1.66894633857984420e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13181020475308580e+00</second>
+						<second>1.11365215652953475e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.99462277474732019e-01</second>
+						<second>2.99851113088361099e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.67371889319369882e-01</second>
+						<second>3.18456245985843434e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.06690371059819383e-01</second>
+						<second>-3.56024315758433352e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49773933841123230e+00</second>
+						<second>1.49762059848112794e+00</second>
 					</item>
 				</goal_state>
-				<score>2.67290253440225278e+00</score>
+				<score>1.69927803521116555e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -66285,31 +66285,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.72204748035363431e+00</second>
+						<second>-1.90014118775710728e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.76075294525565029e-02</second>
+						<second>-3.24176289482759783e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13160171529988962e+00</second>
+						<second>1.40632113490673327e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.17130728058755351e-01</second>
+						<second>3.49256329615662831e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.83063216325978018e-01</second>
+						<second>3.06921015816006060e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.20359409465491096e-01</second>
+						<second>-1.79473968540561024e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49766408053323086e+00</second>
+						<second>1.79452567452363598e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66317,34 +66317,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75631587186465521e+00</second>
+						<second>-1.91978920972133027e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.51201036437878958e-02</second>
+						<second>-2.26224933095799829e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.33285912673882523e+00</second>
+						<second>1.29915914852896597e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.14881591151786644e-01</second>
+						<second>2.45766153099100243e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.75425460659457211e-01</second>
+						<second>2.35050254765815342e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.53304125325520657e-01</second>
+						<second>-1.11255878176859266e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.74782516131849808e+00</second>
+						<second>1.74759244921435131e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55648081361388524e+00</score>
+				<score>1.63177963140479776e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -66375,31 +66375,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75631587186465521e+00</second>
+						<second>-1.86599507389824737e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.51201036437878958e-02</second>
+						<second>-3.12022481166436993e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.33285912673882523e+00</second>
+						<second>1.72480915032231485e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.14881591151786644e-01</second>
+						<second>3.09376102889009463e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.75425460659457211e-01</second>
+						<second>1.67388674299630669e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.53304125325520657e-01</second>
+						<second>-1.88096281174045532e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.74782516131849808e+00</second>
+						<second>2.12704651922756005e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66407,34 +66407,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76872490052123710e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.25957736005298118e-02</second>
+						<second>-1.75035080538460758e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.44629760263244767e+00</second>
+						<second>1.42795588243118177e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.92944299624998505e-01</second>
+						<second>3.05647721498500002e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.57318024282256630e-01</second>
+						<second>2.60795456632877676e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.84525772214657191e-01</second>
+						<second>-3.68506029823346681e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.88873698038749560e+00</second>
+						<second>1.88855792938110034e+00</second>
 					</item>
 				</goal_state>
-				<score>2.34946708802678073e+00</score>
+				<score>1.49955310301714717e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -66555,31 +66555,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68979172565108571e+00</second>
+						<second>-1.55894905759498870e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.40661178458892450e-01</second>
+						<second>2.96700000000000008e+00</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.79794719064283748e-01</second>
+						<second>-6.66991581680690060e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.36820759487802390e-01</second>
+						<second>3.49548592783498091e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.61304873203194576e-01</second>
+						<second>-2.69480018426478241e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.79200750617774440e-01</second>
+						<second>-7.32025269801875322e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.23907407792497670e+00</second>
+						<second>7.55554471920434012e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66587,34 +66587,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54836850645436463e+00</second>
+						<second>1.61453804780154919e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.47154316534740870e-01</second>
+						<second>-5.74778332042633761e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>6.51223582139097590e-01</second>
+						<second>-6.58907953981500816e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.42354329574008531e-01</second>
+						<second>1.23035127886858178e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.39904689182011144e-01</second>
+						<second>-2.98573917268204791e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.77089419744559662e-01</second>
+						<second>3.12755397028339255e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>8.40237716644574251e-01</second>
+						<second>-8.39899102393568242e-01</second>
 					</item>
 				</goal_state>
-				<score>1.53525067035784879e+00</score>
+				<score>9.87761452889668046e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -66645,31 +66645,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73078968255012589e+00</second>
+						<second>1.61453804780154919e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>7.47439562092142625e-03</second>
+						<second>-5.74778332042633761e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.13176583513988849e+00</second>
+						<second>-6.58907953981500816e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>6.00915333414596575e-01</second>
+						<second>1.23035127886858178e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.68593273285678102e-01</second>
+						<second>-2.98573917268204791e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.07673001590367362e-01</second>
+						<second>3.12755397028339255e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.49766195620005260e+00</second>
+						<second>-8.39899102393568242e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66677,34 +66677,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68979172565108571e+00</second>
+						<second>1.78454803113303195e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.40661178458892450e-01</second>
+						<second>-5.21986328394157748e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>8.79794719064283748e-01</second>
+						<second>-8.90829329591369956e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>5.36820759487802390e-01</second>
+						<second>1.22161102828007698e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>4.61304873203194576e-01</second>
+						<second>-3.00201965933721127e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.79200750617774440e-01</second>
+						<second>3.14149986404007286e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.23907407792497670e+00</second>
+						<second>-1.23890537188772010e+00</second>
 					</item>
 				</goal_state>
-				<score>2.33463818253786748e+00</score>
+				<score>1.50816221843623699e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -66735,31 +66735,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72081371807270678e+00</second>
+						<second>1.78454803113303195e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.87625942318822281e-01</second>
+						<second>-5.21986328394157748e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.09343601640325550e+00</second>
+						<second>-8.90829329591369956e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48144178446031205e+00</second>
+						<second>1.22161102828007698e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.99419956227953410e-01</second>
+						<second>-3.00201965933721127e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.33834047628110131e+00</second>
+						<second>3.14149986404007286e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79950887223375622e+00</second>
+						<second>-1.23890537188772010e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66767,34 +66767,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.61950156365418230e+00</second>
+						<second>1.89170556954632141e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.97454211628675858e-01</second>
+						<second>-5.28444508690378290e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.02773810783669828e+00</second>
+						<second>-1.09376148231677695e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.36019588830926397e+00</second>
+						<second>1.09480086944245589e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.12965777391745381e-01</second>
+						<second>-3.02683777992828107e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.57881466548512783e+00</second>
+						<second>3.14149997649151036e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.54904188803764042e+00</second>
+						<second>-1.54876980512850171e+00</second>
 					</item>
 				</goal_state>
-				<score>2.41860131399776090e+00</score>
+				<score>1.66414034076430156e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -66825,31 +66825,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72081371807270678e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.87625942318822281e-01</second>
+						<second>-1.75035080538460758e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.09343601640325550e+00</second>
+						<second>1.42795588243118177e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48144178446031205e+00</second>
+						<second>3.05647721498500002e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.99419956227953410e-01</second>
+						<second>2.60795456632877676e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.33834047628110131e+00</second>
+						<second>-3.68506029823346681e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79950887223375622e+00</second>
+						<second>1.88855792938110034e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66857,34 +66857,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64465585611466958e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.39718353539401885e-01</second>
+						<second>3.22215607485255157e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.20256292724274050e+00</second>
+						<second>1.29119479996841413e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.39565903761189469e+00</second>
+						<second>2.73497267924299459e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.33770541736491033e-01</second>
+						<second>2.45243360007955297e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.48777058420238362e+00</second>
+						<second>1.63132697745417138e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.80306926692887415e+00</second>
+						<second>1.80273501994564977e+00</second>
 					</item>
 				</goal_state>
-				<score>2.28140253301627238e+00</score>
+				<score>1.55361496245913333e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -66915,31 +66915,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72081371807270678e+00</second>
+						<second>-1.86599507389824737e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.87625942318822281e-01</second>
+						<second>-3.12022481166436993e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.09343601640325550e+00</second>
+						<second>1.72480915032231485e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48144178446031205e+00</second>
+						<second>3.09376102889009463e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.99419956227953410e-01</second>
+						<second>1.67388674299630669e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.33834047628110131e+00</second>
+						<second>-1.88096281174045532e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79950887223375622e+00</second>
+						<second>2.12704651922756005e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -66947,34 +66947,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64619669247399325e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.88432768533887807e-01</second>
+						<second>6.79531634732756101e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.31758894412218308e+00</second>
+						<second>1.42630378192705698e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.43687907238766943e+00</second>
+						<second>3.00250711989020147e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.45695751063011558e-01</second>
+						<second>2.75140568971398658e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.43028504085827768e+00</second>
+						<second>2.15538620387363461e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95503282063708461e+00</second>
+						<second>1.95459330631150041e+00</second>
 					</item>
 				</goal_state>
-				<score>2.06597250747945482e+00</score>
+				<score>1.39517578583557483e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -67095,31 +67095,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65935318302968660e+00</second>
+						<second>1.61453804780154919e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.81229934056232403e-02</second>
+						<second>-5.74778332042633761e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.23426921659290190e-01</second>
+						<second>-6.58907953981500816e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.55886758024092398e+00</second>
+						<second>1.23035127886858178e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.57382342392445596e+00</second>
+						<second>-2.98573917268204791e+00</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.27152848376685529e-01</second>
+						<second>3.12755397028339255e+00</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.18296119694657120e+00</second>
+						<second>-8.39899102393568242e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -67127,34 +67127,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.54999363363824072e+00</second>
+						<second>-1.61343186200619915e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.40485457829517990e-01</second>
+						<second>5.81570705497589310e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.51268592557595616e-01</second>
+						<second>6.58137847840051138e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.60882023109323580e+00</second>
+						<second>-1.24870062678076016e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.70734578584733310e+00</second>
+						<second>-1.58545126312272938e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.70995644968146204e-01</second>
+						<second>1.40443020027788655e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.38228589719372530e-01</second>
+						<second>8.38107333644363517e-01</second>
 					</item>
 				</goal_state>
-				<score>1.53370612056787081e+00</score>
+				<score>9.85237220932055624e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -67185,31 +67185,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73996181694739382e+00</second>
+						<second>-1.61343186200619915e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.41229827306441139e-02</second>
+						<second>5.81570705497589310e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12838484187793964e+00</second>
+						<second>6.58137847840051138e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.56236271816107708e+00</second>
+						<second>-1.24870062678076016e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.59042257284734845e+00</second>
+						<second>-1.58545126312272938e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.80263047342040933e-01</second>
+						<second>1.40443020027788655e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.48699258630051001e+00</second>
+						<second>8.38107333644363517e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -67217,34 +67217,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.70134941636534709e+00</second>
+						<second>-1.78609988600953318e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.30243420063538839e-01</second>
+						<second>4.74565991505485826e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.84399091838568463e-01</second>
+						<second>8.93785635830465108e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.63256653815908237e+00</second>
+						<second>-1.26240201874057434e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.70388791440015375e+00</second>
+						<second>-1.40873922349389336e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.65452915922833155e-01</second>
+						<second>-5.29525563791199191e-03</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.24448354148807572e+00</second>
+						<second>1.24405072539902739e+00</second>
 					</item>
 				</goal_state>
-				<score>2.34944416305658743e+00</score>
+				<score>1.51256018727705166e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -67275,31 +67275,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.67625567210292359e+00</second>
+						<second>-1.78609988600953318e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.61960506364601520e-01</second>
+						<second>4.74565991505485826e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.78083761912612393e-01</second>
+						<second>8.93785635830465108e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.56642561142902892e+00</second>
+						<second>-1.26240201874057434e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.64997149645367847e+00</second>
+						<second>-1.40873922349389336e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.07293225787140800e-01</second>
+						<second>-5.29525563791199191e-03</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.24415705776787799e+00</second>
+						<second>1.24405072539902739e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -67307,34 +67307,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75687257357049575e+00</second>
+						<second>-1.88815765328809237e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.74018203165185459e-01</second>
+						<second>4.60778941111278095e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.07026347532716670e+00</second>
+						<second>1.09133044859685335e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.57636530400940744e+00</second>
+						<second>-1.29259523105868995e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.64059533251779133e+00</second>
+						<second>-1.31731199527982568e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-3.84840448906571209e-01</second>
+						<second>-1.47475156187549424e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.54399232674553488e+00</second>
+						<second>1.54390275564821899e+00</second>
 					</item>
 				</goal_state>
-				<score>2.41662736443792037e+00</score>
+				<score>1.66399517540653991e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -67365,31 +67365,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73715829499825447e+00</second>
+						<second>-1.89386929721354336e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.31874036502090752e-01</second>
+						<second>8.29760627538708995e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.20538534307321155e+00</second>
+						<second>1.08784112773327002e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.52777638627188850e+00</second>
+						<second>-5.16151411380952885e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.16582545185260789e-01</second>
+						<second>-7.00551540887954932e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.27889349678314224e+00</second>
+						<second>5.19628380937716614e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95356289603521227e+00</second>
+						<second>1.54396408201816504e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -67397,34 +67397,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.72211726669378384e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.86490093379832733e-01</second>
+						<second>-2.59812075916126192e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.09436750628503887e+00</second>
+						<second>1.28947713792853635e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.48287753893405450e+00</second>
+						<second>-2.71965958666329166e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>5.97532130404137107e-01</second>
+						<second>-2.44292411344753185e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.33974610013822426e+00</second>
+						<second>-1.56059048282625068e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.79943072227715772e+00</second>
+						<second>1.79917378946996198e+00</second>
 					</item>
 				</goal_state>
-				<score>2.19808988873429856e+00</score>
+				<score>1.55737552920137190e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -67455,31 +67455,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.64397562085141113e+00</second>
+						<second>-1.87790646157441721e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.90431335606353291e-01</second>
+						<second>8.16073062843705038e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.31609272618829398e+00</second>
+						<second>1.73253012695474262e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.43425117612246478e+00</second>
+						<second>-1.30659944865078148e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>7.48905466185118773e-01</second>
+						<second>-8.61462304007950541e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.42760024651516648e+00</second>
+						<second>2.40036025761119452e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95478867818194790e+00</second>
+						<second>2.19857969550768972e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -67487,34 +67487,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73715829499825447e+00</second>
+						<second>-1.91977390507350543e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>5.31874036502090752e-01</second>
+						<second>-6.34316625145386476e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>1.20538534307321155e+00</second>
+						<second>1.42627566972801967e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-2.52777638627188850e+00</second>
+						<second>-3.00380404178495430e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>6.16582545185260789e-01</second>
+						<second>-2.75166563066459424e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.27889349678314224e+00</second>
+						<second>-2.10977596337731471e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.95356289603521227e+00</second>
+						<second>1.95325654950827676e+00</second>
 					</item>
 				</goal_state>
-				<score>2.00557675314476125e+00</score>
+				<score>1.39729052209582372e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -67635,31 +67635,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60432212994440104e+00</second>
+						<second>-1.66302647432547679e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.52321327387608924e-01</second>
+						<second>2.65002027421598119e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.45179492403312227e-01</second>
+						<second>9.25399729298417850e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.49801098922233633e+00</second>
+						<second>-4.64985875733987419e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.46389592936861757e+00</second>
+						<second>-5.61381437370012115e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.33218681738235017e-02</second>
+						<second>1.28123988316595355e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.06027418642082738e+00</second>
+						<second>1.06041138629980480e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -67667,34 +67667,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.50790635279612384e+00</second>
+						<second>-1.54584833779461839e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.27036491441373353e-02</second>
+						<second>1.37908508043266542e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.68178305180508914e-01</second>
+						<second>6.62336614549699276e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.55508537688013249e+00</second>
+						<second>-4.01649453617170471e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.55687353397126627e+00</second>
+						<second>-4.74026219846805486e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.25615090816895722e-02</second>
+						<second>4.77968636267558505e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-7.46005765230304596e-01</second>
+						<second>7.46038819332114245e-01</second>
 					</item>
 				</goal_state>
-				<score>1.43999004478396553e+00</score>
+				<score>9.04630888229814162e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -67725,31 +67725,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68808114415395027e+00</second>
+						<second>-1.76208733529689598e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.47673657223877791e-01</second>
+						<second>2.59806061618128303e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.16446586361639270e+00</second>
+						<second>1.14021093449284239e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.49879072446559158e+00</second>
+						<second>-4.77199050010719772e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.50414336959512163e+00</second>
+						<second>-5.10076821394410573e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.76544409128169370e-02</second>
+						<second>1.01756097749161542e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.38492865636368911e+00</second>
+						<second>1.38462203640853709e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -67757,34 +67757,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.66493864038840234e+00</second>
+						<second>-1.72099065748480484e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.64049791182816782e-02</second>
+						<second>1.20974721576161626e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.23348468566452363e-01</second>
+						<second>9.15637928792801370e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.57371020971062547e+00</second>
+						<second>-3.92917285771717584e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.58515255359326046e+00</second>
+						<second>-4.26356096318983913e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.18546481179678184e-01</second>
+						<second>-1.03633370416497898e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.18312779682388003e+00</second>
+						<second>1.18299600571132690e+00</second>
 					</item>
 				</goal_state>
-				<score>2.39200751925229671e+00</score>
+				<score>1.50869843230390266e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -67815,31 +67815,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.68808114415395027e+00</second>
+						<second>-1.88700256219789453e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.47673657223877791e-01</second>
+						<second>2.88640084857520962e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.16446586361639270e+00</second>
+						<second>1.42067949733638543e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.49879072446559158e+00</second>
+						<second>-3.87068263142991587e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.50414336959512163e+00</second>
+						<second>-3.37049277169207739e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.76544409128169370e-02</second>
+						<second>1.31993904475240426e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.38492865636368911e+00</second>
+						<second>1.80317881069358754e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -67847,34 +67847,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.74730105002795311e+00</second>
+						<second>-1.84420903033506023e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.31279750608886919e-02</second>
+						<second>1.77133606962374623e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12815762385272533e+00</second>
+						<second>1.10825863297278904e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.57721528822870471e+00</second>
+						<second>-2.96268883582265496e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.60325952270787031e+00</second>
+						<second>-3.18961945754766552e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.68734127418638552e-01</second>
+						<second>4.69494692858823393e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.48701123194171880e+00</second>
+						<second>1.48697836131085581e+00</second>
 					</item>
 				</goal_state>
-				<score>2.68569520792969518e+00</score>
+				<score>1.70012149100215587e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -67905,31 +67905,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71882310356493284e+00</second>
+						<second>-1.89386929721354336e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-1.10750847382868039e-02</second>
+						<second>8.29760627538708995e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12843094630742358e+00</second>
+						<second>1.08784112773327002e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52219085085021399e+00</second>
+						<second>-5.16151411380952885e-02</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.55487998991442478e+00</second>
+						<second>-7.00551540887954932e-02</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.11681289833377861e-01</second>
+						<second>5.19628380937716614e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.48705804397222718e+00</second>
+						<second>1.54396408201816504e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -67937,34 +67937,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75665877496725464e+00</second>
+						<second>-1.91956372614706150e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.26669164784406123e-02</second>
+						<second>2.27477177112056367e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33642150371356694e+00</second>
+						<second>1.30229037924990299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52698666501872848e+00</second>
+						<second>-2.48535133471754155e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56640553681646733e+00</second>
+						<second>-2.37345609484678366e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.50381118960854632e-01</second>
+						<second>1.11193526582225921e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75005751987880021e+00</second>
+						<second>1.74984045300641466e+00</second>
 					</item>
 				</goal_state>
-				<score>2.55544347897950264e+00</score>
+				<score>1.63076653849638098e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -67995,31 +67995,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.75665877496725464e+00</second>
+						<second>-1.88815765328809237e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.26669164784406123e-02</second>
+						<second>4.60778941111278095e-02</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.33642150371356694e+00</second>
+						<second>1.09133044859685335e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52698666501872848e+00</second>
+						<second>-1.29259523105868995e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.56640553681646733e+00</second>
+						<second>-1.31731199527982568e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.50381118960854632e-01</second>
+						<second>-1.47475156187549424e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.75005751987880021e+00</second>
+						<second>1.54390275564821899e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -68027,34 +68027,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76948165787523615e+00</second>
+						<second>-1.91979999999999995e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-5.14446121960135117e-02</second>
+						<second>1.75950422698193165e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.44840159371996102e+00</second>
+						<second>1.42985134598723795e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.55019538370574494e+00</second>
+						<second>-3.05016536699115048e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.58563804147301823e+00</second>
+						<second>-2.60114334620401677e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-2.82890739969862748e-01</second>
+						<second>3.81143967627614946e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.89053067811971709e+00</second>
+						<second>1.89040971471770902e+00</second>
 					</item>
 				</goal_state>
-				<score>2.34645678975905270e+00</score>
+				<score>1.49758072120579344e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -68175,31 +68175,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.51330263842823332e+00</second>
+						<second>-1.56982162934551939e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.45503843151062440e-01</second>
+						<second>3.81866707160441576e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.39483124730225216e-01</second>
+						<second>9.14668718564141336e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40109970179178100e+00</second>
+						<second>-5.55143459240583947e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.33227023842397063e+00</second>
+						<second>-7.13990439956549761e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.01882743133928066e-01</second>
+						<second>2.76533566362661687e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.56960312185424677e-01</second>
+						<second>8.56864089928061845e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -68207,34 +68207,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.42874672944860848e+00</second>
+						<second>-1.46361297357058984e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.64711874275887765e-01</second>
+						<second>2.97546949497321023e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-6.63789757764832955e-01</second>
+						<second>6.51329277414897212e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.45636582181556484e+00</second>
+						<second>-4.93531178628820622e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.38632999381627364e+00</second>
+						<second>-6.69686345403154415e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.41383692371532227e-01</second>
+						<second>1.93849122447252803e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-5.69245659440157814e-01</second>
+						<second>5.69049761421972278e-01</second>
 					</item>
 				</goal_state>
-				<score>1.16318290980713490e+00</score>
+				<score>7.22438579066884828e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -68265,31 +68265,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61579486727849186e+00</second>
+						<second>-1.67822116850250258e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.54850425699016947e-01</second>
+						<second>3.62087665420296911e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.17070704193088182e+00</second>
+						<second>1.14373232366815691e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.42353665347439007e+00</second>
+						<second>-5.77874902032840754e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.40356964528046957e+00</second>
+						<second>-6.46128765551950868e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.55463653309889954e-01</second>
+						<second>2.38147790779070834e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.20734282783182345e+00</second>
+						<second>1.20709031428871727e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -68297,34 +68297,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60457722747064335e+00</second>
+						<second>-1.65445884758801021e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.52889873101456270e-01</second>
+						<second>2.46385082881061312e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.45210298323762022e-01</second>
+						<second>9.29427396077215251e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.49918105216335507e+00</second>
+						<second>-4.95011306375789384e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.46461610046384205e+00</second>
+						<second>-5.80586534799266252e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.35275043253553673e-02</second>
+						<second>1.11611924745143573e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.06052502812255312e+00</second>
+						<second>1.06043121871318458e+00</second>
 					</item>
 				</goal_state>
-				<score>2.34753557561738679e+00</score>
+				<score>1.46969297655521275e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -68355,31 +68355,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71553405831944517e+00</second>
+						<second>-1.57426708315378394e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.81363525447515306e+00</second>
+						<second>4.38378022323728633e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.30836415022411101e+00</second>
+						<second>1.10044085842871753e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.25372812860789495e-01</second>
+						<second>-6.66703132624735795e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51524655967627986e+00</second>
+						<second>-7.85628985457296092e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.91963189805860052e-01</second>
+						<second>3.92881158292083865e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.42495041036265047e+00</second>
+						<second>9.36114210537299152e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -68387,34 +68387,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.73694904272654216e+00</second>
+						<second>-1.74403817478999668e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.92326421045417906e+00</second>
+						<second>2.29426785296631380e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.15068219662851279e+00</second>
+						<second>1.14800971734457891e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-5.40079300316176014e-01</second>
+						<second>-5.23411870937134815e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.58429332717227744e+00</second>
+						<second>-5.44671713902012633e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.57959050943139037e-02</second>
+						<second>6.79226588938623421e-02</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.38463018502307267e+00</second>
+						<second>1.38457547011420190e+00</second>
 					</item>
 				</goal_state>
-				<score>2.79776770123972574e+00</score>
+				<score>1.75263298789788746e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -68445,31 +68445,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.73640932235893741e+00</second>
+						<second>-1.68144071268726036e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96310799106575162e+00</second>
+						<second>4.42159505343838410e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.57358260983191656e+00</second>
+						<second>1.24233450733134299e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.49928128043647169e+00</second>
+						<second>-6.05317821629667741e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.57746392793297119e+00</second>
+						<second>-6.73486639460211478e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.13778823383798322e+00</second>
+						<second>3.45480193044623796e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.83803655257394549e+00</second>
+						<second>1.22462592956511296e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -68477,34 +68477,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>1.74755047147047371e+00</second>
+						<second>-1.81760528477582772e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.96699993615339963e+00</second>
+						<second>2.76177596583099039e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.34997560633739044e+00</second>
+						<second>1.32442347546017336e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52296230729895044e+00</second>
+						<second>-4.86081654668456431e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.55986805729571332e+00</second>
+						<second>-4.67095485167669078e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.13241144504164248e+00</second>
+						<second>1.06900764376276700e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.62079364996864350e+00</second>
+						<second>1.62083999141562618e+00</second>
 					</item>
 				</goal_state>
-				<score>2.80047577822184390e+00</score>
+				<score>1.75805592642966135e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -68535,31 +68535,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71670712376820056e+00</second>
+						<second>-1.85927848136926110e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.79003587336505066e-01</second>
+						<second>3.63634056874405642e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.45375954288232201e+00</second>
+						<second>1.51934021306274536e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.46477275640420990e+00</second>
+						<second>-4.49671522543681590e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51932267323400350e+00</second>
+						<second>-3.69485442371662365e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.03120276869565509e-03</second>
+						<second>2.02830256321682473e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.68403153904001113e+00</second>
+						<second>1.83807354267429246e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -68567,34 +68567,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.76387218518463307e+00</second>
+						<second>-1.88700256219789453e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.04385140963515533e-01</second>
+						<second>2.88640084857520962e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.46364388490693775e+00</second>
+						<second>1.42067949733638543e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.52978903390368748e+00</second>
+						<second>-3.87068263142991587e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.58778388074027976e+00</second>
+						<second>-3.37049277169207739e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>-1.00004754114545027e-01</second>
+						<second>1.31993904475240426e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.80318063824447816e+00</second>
+						<second>1.80317881069358754e+00</second>
 					</item>
 				</goal_state>
-				<score>2.56191824615771191e+00</score>
+				<score>1.61272385644519817e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -68805,31 +68805,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52071882229153910e+00</second>
+						<second>-1.57426708315378394e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.46896069697674503e-01</second>
+						<second>4.38378022323728633e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.19807437660355820e+00</second>
+						<second>1.10044085842871753e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.31018377265576191e+00</second>
+						<second>-6.66703132624735795e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.26892992180041730e+00</second>
+						<second>-7.85628985457296092e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.96174585325917594e-01</second>
+						<second>3.92881158292083865e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.50075773335430696e-01</second>
+						<second>9.36114210537299152e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -68837,34 +68837,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.51330263842823332e+00</second>
+						<second>-1.55897396286153800e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.45503843151062440e-01</second>
+						<second>3.52949742001497035e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.39483124730225216e-01</second>
+						<second>9.20800704601165032e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.40109970179178100e+00</second>
+						<second>-5.94875299263217028e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.33227023842397063e+00</second>
+						<second>-7.34041376320279215e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.01882743133928066e-01</second>
+						<second>2.59853310892098399e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-8.56960312185424677e-01</second>
+						<second>8.56853925997616339e-01</second>
 					</item>
 				</goal_state>
-				<score>2.10312932549662834e+00</score>
+				<score>1.31196824935623679e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -68895,31 +68895,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.60432212994440104e+00</second>
+						<second>-1.66154276403164358e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>1.52321327387608924e-01</second>
+						<second>4.04469164023093242e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.45179492403312227e-01</second>
+						<second>1.25426878329735403e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.49801098922233633e+00</second>
+						<second>-6.51147066839779409e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.46389592936861757e+00</second>
+						<second>-7.01401988909576724e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.33218681738235017e-02</second>
+						<second>3.17846803577951642e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.06027418642082738e+00</second>
+						<second>1.22466064579580669e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -68927,34 +68927,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.61579486727849186e+00</second>
+						<second>-1.66890062865375977e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.54850425699016947e-01</second>
+						<second>3.44878920309086678e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.17070704193088182e+00</second>
+						<second>1.14870200371765319e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.42353665347439007e+00</second>
+						<second>-6.01267657942819556e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.40356964528046957e+00</second>
+						<second>-6.60951324920375005e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.55463653309889954e-01</second>
+						<second>2.24300301117278611e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.20734282783182345e+00</second>
+						<second>1.20698788322814221e+00</second>
 					</item>
 				</goal_state>
-				<score>2.80975630011534427e+00</score>
+				<score>1.75975537271063853e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -68985,31 +68985,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.65961197511560377e+00</second>
+						<second>-1.66154276403164358e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.69646067714778859e+00</second>
+						<second>4.04469164023093242e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.53031577900772309e+00</second>
+						<second>1.25426878329735403e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-7.31741967551904460e-01</second>
+						<second>-6.51147066839779409e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.45910974851273290e+00</second>
+						<second>-7.01401988909576724e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.94840481619833039e-01</second>
+						<second>3.17846803577951642e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.44337029678732121e+00</second>
+						<second>1.22466064579580669e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -69017,34 +69017,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.71553405831944517e+00</second>
+						<second>-1.72551061261849803e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>-2.81363525447515306e+00</second>
+						<second>3.43722554569098837e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.30836415022411101e+00</second>
+						<second>1.30346124904578331e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>-6.25372812860789495e-01</second>
+						<second>-6.06239498336005544e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.51524655967627986e+00</second>
+						<second>-6.12100914592791034e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>1.91963189805860052e-01</second>
+						<second>2.06367326820116381e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>1.42495041036265047e+00</second>
+						<second>1.42471911030386877e+00</second>
 					</item>
 				</goal_state>
-				<score>2.98187466200491524e+00</score>
+				<score>1.86758612584145639e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -69345,31 +69345,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52071882229153910e+00</second>
+						<second>-1.42322091470254408e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.46896069697674503e-01</second>
+						<second>5.27769940066721732e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.19807437660355820e+00</second>
+						<second>9.63420644884803168e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.31018377265576191e+00</second>
+						<second>-7.31448153369939069e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.26892992180041730e+00</second>
+						<second>-9.54059296417269609e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.96174585325917594e-01</second>
+						<second>5.97451793807029619e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.50075773335430696e-01</second>
+						<second>4.90535462375142062e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -69377,34 +69377,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.38678655319987110e+00</second>
+						<second>-1.41263248771934458e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.65052216112931927e-01</second>
+						<second>4.84481685400962481e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-8.57367522993721987e-01</second>
+						<second>8.44090012986214333e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.31181443074315540e+00</second>
+						<second>-6.90512327231927792e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.18546025666860277e+00</second>
+						<second>-9.17198192716616956e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>4.58382262714206234e-01</second>
+						<second>4.85891012343127537e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.73062456092897821e-01</second>
+						<second>4.73050222759891559e-01</second>
 					</item>
 				</goal_state>
-				<score>1.26524191534659414e+00</score>
+				<score>7.90688448921925691e-02</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -69435,31 +69435,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39616319121428889e+00</second>
+						<second>-1.66154276403164358e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.06742586034521902e-01</second>
+						<second>4.04469164023093242e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.77979776655621968e-01</second>
+						<second>1.25426878329735403e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27487058200195236e+00</second>
+						<second>-6.51147066839779409e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.15251005725304756e+00</second>
+						<second>-7.01401988909576724e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70876784890270272e-01</second>
+						<second>3.17846803577951642e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.90456580514297746e-01</second>
+						<second>1.22466064579580669e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -69467,34 +69467,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.52413979837612534e+00</second>
+						<second>-1.57357274577667483e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>3.28152527918693759e-01</second>
+						<second>4.36904161078742470e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.12452626419333401e+00</second>
+						<second>1.10084362881828435e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.34116611895166127e+00</second>
+						<second>-6.68865086163462408e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.28991850224467264e+00</second>
+						<second>-7.86597612861668294e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>3.38119975227272440e-01</second>
+						<second>3.92277581517743668e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-9.36118128040124842e-01</second>
+						<second>9.36004304751068439e-01</second>
 					</item>
 				</goal_state>
-				<score>2.52323493338123273e+00</score>
+				<score>1.57801983650227490e-01</score>
 			</item>
 			<item>
 				<reached>1</reached>
@@ -69525,31 +69525,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39616319121428889e+00</second>
+						<second>-1.61181417444521946e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.06742586034521902e-01</second>
+						<second>5.69588366801066170e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.77979776655621968e-01</second>
+						<second>1.44571238207649810e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27487058200195236e+00</second>
+						<second>-8.26371626033692852e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.15251005725304756e+00</second>
+						<second>-7.91194832551771698e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70876784890270272e-01</second>
+						<second>6.49385492738040138e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.90456580514297746e-01</second>
+						<second>1.07752470756645602e+00</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -69557,34 +69557,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.59810989599078579e+00</second>
+						<second>-1.66154276403164358e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>2.96473804212760261e-01</second>
+						<second>4.04469164023093242e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.28282700582325404e+00</second>
+						<second>1.25426878329735403e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.36326996285087398e+00</second>
+						<second>-6.51147066839779409e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.35904914937748966e+00</second>
+						<second>-7.01401988909576724e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>2.45176015426882166e-01</second>
+						<second>3.17846803577951642e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-1.22484571923982077e+00</second>
+						<second>1.22466064579580669e+00</second>
 					</item>
 				</goal_state>
-				<score>2.96501439914651321e+00</score>
+				<score>1.86077782586783647e-01</score>
 			</item>
 			<item>
 				<reached>0</reached>
@@ -69975,31 +69975,31 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39776116547487450e+00</second>
+						<second>-1.56060766240068260e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.46742538136349676e-01</second>
+						<second>5.46098525598183615e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-1.01345139506047777e+00</second>
+						<second>1.24776335915352932e+00</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.23123050539687284e+00</second>
+						<second>-7.77489629574526941e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.12332802065480664e+00</second>
+						<second>-8.61080609651629802e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>6.72487916088626458e-01</second>
+						<second>6.21922614025692266e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.26449463597276868e-01</second>
+						<second>8.49917438889326693e-01</second>
 					</item>
 				</seed_state>
 				<goal_state>
@@ -70007,34 +70007,34 @@
 					<item_version>0</item_version>
 					<item>
 						<first>joint_b</first>
-						<second>-1.39603177060979333e+00</second>
+						<second>-1.42322091470254408e+00</second>
 					</item>
 					<item>
 						<first>joint_e</first>
-						<second>4.06322556202257490e-01</second>
+						<second>5.27769940066721732e-01</second>
 					</item>
 					<item>
 						<first>joint_l</first>
-						<second>-9.78087793183815224e-01</second>
+						<second>9.63420644884803168e-01</second>
 					</item>
 					<item>
 						<first>joint_r</first>
-						<second>2.27430259177735383e+00</second>
+						<second>-7.31448153369939069e-01</second>
 					</item>
 					<item>
 						<first>joint_s</first>
-						<second>2.15239712963725127e+00</second>
+						<second>-9.54059296417269609e-01</second>
 					</item>
 					<item>
 						<first>joint_t</first>
-						<second>5.70781356256298444e-01</second>
+						<second>5.97451793807029619e-01</second>
 					</item>
 					<item>
 						<first>joint_u</first>
-						<second>-4.90530829545758496e-01</second>
+						<second>4.90535462375142062e-01</second>
 					</item>
 				</goal_state>
-				<score>1.45593161267621474e+00</score>
+				<score>9.11788743890088599e-02</score>
 			</item>
 			<item>
 				<reached>0</reached>

--- a/include/reach_ros/evaluation/distance_penalty_moveit.h
+++ b/include/reach_ros/evaluation/distance_penalty_moveit.h
@@ -43,19 +43,22 @@ class DistancePenaltyMoveIt : public reach::Evaluator
 {
 public:
   DistancePenaltyMoveIt(moveit::core::RobotModelConstPtr model, const std::string& planning_group,
-                        const double dist_threshold, int exponent, std::string collision_mesh_filename,
-                        std::vector<std::string> touch_links);
+                        const double dist_threshold, int exponent);
   double calculateScore(const std::map<std::string, double>& pose) const override;
 
-private:
+  void addCollisionMesh(const std::string& collision_mesh_filename, const std::string& collision_mesh_frame);
+
+  void setTouchLinks(const std::vector<std::string>& touch_links);
+
+protected:
   moveit::core::RobotModelConstPtr model_;
   const moveit::core::JointModelGroup* jmg_;
   const double dist_threshold_;
   const int exponent_;
-  const std::string collision_mesh_filename_;
-  const std::vector<std::string> touch_links_;
 
   planning_scene::PlanningScenePtr scene_;
+
+  static std::string COLLISION_OBJECT_NAME;
 };
 
 struct DistancePenaltyMoveItFactory : public reach::EvaluatorFactory

--- a/src/evaluation/distance_penalty_moveit.cpp
+++ b/src/evaluation/distance_penalty_moveit.cpp
@@ -64,7 +64,8 @@ double DistancePenaltyMoveIt::calculateScore(const std::map<std::string, double>
   state.update();
 
   const double dist = scene_->distanceToCollision(state, scene_->getAllowedCollisionMatrix());
-  return std::pow((dist / dist_threshold_), exponent_);
+  const double clipped_distance = std::min(std::abs(dist / dist_threshold_), 1.0);
+  return std::pow(clipped_distance, exponent_);
 }
 
 reach::Evaluator::ConstPtr DistancePenaltyMoveItFactory::create(const YAML::Node& config) const

--- a/src/evaluation/distance_penalty_moveit.cpp
+++ b/src/evaluation/distance_penalty_moveit.cpp
@@ -25,29 +25,34 @@ namespace reach_ros
 {
 namespace evaluation
 {
+std::string DistancePenaltyMoveIt::COLLISION_OBJECT_NAME = "reach_object";
+
 DistancePenaltyMoveIt::DistancePenaltyMoveIt(moveit::core::RobotModelConstPtr model, const std::string& planning_group,
-                                             const double dist_threshold, int exponent,
-                                             std::string collision_mesh_filename, std::vector<std::string> touch_links)
+                                             const double dist_threshold, int exponent)
   : model_(model)
   , jmg_(model_->getJointModelGroup(planning_group))
   , dist_threshold_(dist_threshold)
   , exponent_(exponent)
-  , collision_mesh_filename_(collision_mesh_filename)
-  , touch_links_(std::move(touch_links))
 {
   if (!jmg_)
     throw std::runtime_error("Failed to get joint model group");
 
   scene_.reset(new planning_scene::PlanningScene(model_));
+}
 
-  // Add the collision mesh object to the planning scene
-  const std::string object_name = "reach_object";
+void DistancePenaltyMoveIt::addCollisionMesh(const std::string& collision_mesh_filename,
+                                             const std::string& collision_mesh_frame)
+{
+  // Add the collision object to the planning scene
   moveit_msgs::CollisionObject obj =
-      utils::createCollisionObject(collision_mesh_filename_, jmg_->getSolverInstance()->getBaseFrame(), object_name);
+      utils::createCollisionObject(collision_mesh_filename, collision_mesh_frame, COLLISION_OBJECT_NAME);
   if (!scene_->processCollisionObjectMsg(obj))
     throw std::runtime_error("Failed to add collision mesh to planning scene");
+}
 
-  scene_->getAllowedCollisionMatrixNonConst().setEntry(object_name, touch_links_, true);
+void DistancePenaltyMoveIt::setTouchLinks(const std::vector<std::string>& touch_links)
+{
+  scene_->getAllowedCollisionMatrixNonConst().setEntry(COLLISION_OBJECT_NAME, touch_links, true);
 }
 
 double DistancePenaltyMoveIt::calculateScore(const std::map<std::string, double>& pose) const
@@ -67,16 +72,43 @@ reach::Evaluator::ConstPtr DistancePenaltyMoveItFactory::create(const YAML::Node
   auto planning_group = reach::get<std::string>(config, "planning_group");
   auto dist_threshold = reach::get<double>(config, "distance_threshold");
   auto exponent = reach::get<int>(config, "exponent");
-  auto collision_mesh_filename = reach::get<std::string>(config, "collision_mesh_filename");
-  auto touch_links = reach::get<std::vector<std::string>>(config, "touch_links");
 
   utils::initROS();
   moveit::core::RobotModelConstPtr model = moveit::planning_interface::getSharedRobotModel("robot_description");
   if (!model)
     throw std::runtime_error("Failed to initialize robot model pointer");
 
-  return std::make_shared<DistancePenaltyMoveIt>(model, planning_group, dist_threshold, exponent,
-                                                 collision_mesh_filename, touch_links);
+  auto evaluator = std::make_shared<DistancePenaltyMoveIt>(model, planning_group, dist_threshold, exponent);
+
+  // Optionally add a collision mesh
+  const std::string collision_mesh_filename_key = "collision_mesh_filename";
+  const std::string collision_mesh_frame_key = "collision_mesh_frame";
+  if (config[collision_mesh_filename_key])
+  {
+    auto collision_mesh_filename = reach::get<std::string>(config, collision_mesh_filename_key);
+    const moveit::core::JointModelGroup* jmg = model->getJointModelGroup(planning_group);
+    if (!jmg)
+      throw std::runtime_error("Joint model group '" + planning_group + "' does not exist");
+
+    kinematics::KinematicsBaseConstPtr solver = jmg->getSolverInstance();
+    if (!solver)
+      throw std::runtime_error("No IK solver defined for joint model group '" + planning_group + "'");
+
+    std::string collision_mesh_frame = config[collision_mesh_frame_key] ?
+                                           reach::get<std::string>(config, collision_mesh_frame_key) :
+                                           solver->getBaseFrame();
+
+    evaluator->addCollisionMesh(collision_mesh_filename, collision_mesh_frame);
+  }
+
+  const std::string touch_links_key = "touch_links";
+  if (config[touch_links_key])
+  {
+    auto touch_links = reach::get<std::vector<std::string>>(config, touch_links_key);
+    evaluator->setTouchLinks(touch_links);
+  }
+
+  return evaluator;
 }
 
 }  // namespace evaluation


### PR DESCRIPTION
This PR updates the collision distance evaluator to optionally accept a collision mesh in addition to the shapes defined in the URDF. It also clips the cost on [0, 1] to prevent infinite values when no collisions are detected.