### PR TITLE
Minor Updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ catkin_package(
   INCLUDE_DIRS
   include
   LIBRARIES
-  ${PROJECT_NAME}_plugins
+  ${PROJECT_NAME}
   CATKIN_DEPENDS
   tf2_eigen
   interactive_markers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
-cmake_minimum_required(VERSION 2.8.3)
-project(reach_ros)
+cmake_minimum_required(VERSION 3.10.0)
 
-add_compile_options(-std=c++14)
+# Extract package name and version from package.xml
+find_package(ros_industrial_cmake_boilerplate REQUIRED)
+extract_package_metadata(pkg)
+project(${pkg_extracted_name} VERSION ${pkg_extracted_version} LANGUAGES CXX)
 
 find_package(reach REQUIRED)
 
@@ -54,6 +56,7 @@ target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} reach::reach)
 # Plugin Library
 add_library(${PROJECT_NAME}_plugins SHARED src/plugins.cpp)
 target_link_libraries(${PROJECT_NAME}_plugins ${PROJECT_NAME})
+target_cxx_version(${PROJECT_NAME}_plugins PUBLIC VERSION 14)
 
 # Reach study node
 add_executable(${PROJECT_NAME}_node src/reach_study_node.cpp)
@@ -62,6 +65,7 @@ target_link_libraries(
   ${catkin_LIBRARIES}
   yaml-cpp
   reach::reach)
+target_cxx_version(${PROJECT_NAME}_node PUBLIC VERSION 14)
 
 # Demo
 add_subdirectory(demo)

--- a/include/reach_ros/display/ros_display.h
+++ b/include/reach_ros/display/ros_display.h
@@ -17,7 +17,6 @@
 #define REACH_ROS_ROS_REACH_DISPLAY_H
 
 #include <reach/interfaces/display.h>
-
 #include <interactive_markers/interactive_marker_server.h>
 #include <ros/node_handle.h>
 #include <ros/publisher.h>
@@ -36,7 +35,7 @@ public:
   void showResults(const reach::ReachResult& db) const override;
   void showReachNeighborhood(const std::map<std::size_t, reach::ReachRecord>& neighborhood) const override;
 
-  void setCollisionMarker(std::string collision_mesh_filename, const std::string collision_mesh_frame);
+  void setCollisionMarker(const std::string& collision_mesh_filename, const std::string& collision_mesh_frame);
 
 protected:
   const std::string kinematic_base_frame_;

--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>ros_industrial_cmake_boilerplate</build_depend>
   <depend>tf2_eigen</depend>
   <depend>interactive_markers</depend>
   <depend>moveit_core</depend>

--- a/src/display/ros_display.cpp
+++ b/src/display/ros_display.cpp
@@ -100,7 +100,7 @@ void ROSDisplay::showReachNeighborhood(const std::map<std::size_t, reach::ReachR
   }
 }
 
-void ROSDisplay::setCollisionMarker(std::string collision_mesh_filename, const std::string collision_mesh_frame)
+void ROSDisplay::setCollisionMarker(const std::string& collision_mesh_filename, const std::string& collision_mesh_frame)
 {
   visualization_msgs::Marker marker;
   marker.header.frame_id = collision_mesh_frame;


### PR DESCRIPTION
Various updates per commit messages. The most important is the export of the `reach_ros` library for linking by downstream projects. This resolves the issues for the ROS1 plugin libraries described [here](https://github.com/ros-industrial/reach_ros2/issues/13)