### PR TITLE
Add ManipulabilityRatioSigmoidMoveIt

### DIFF
--- a/include/reach_ros/evaluation/manipulability_moveit.h
+++ b/include/reach_ros/evaluation/manipulability_moveit.h
@@ -56,6 +56,20 @@ struct ManipulabilityMoveItFactory : public reach::EvaluatorFactory
   reach::Evaluator::ConstPtr create(const YAML::Node& config) const override;
 };
 
+class ManipulabilityRatioSigmoid : public ManipulabilityMoveIt
+{
+public:
+  using ManipulabilityMoveIt::ManipulabilityMoveIt;
+  virtual double calculateScore(const Eigen::MatrixXd& jacobian_singular_values) const override;
+};
+
+struct ManipulabilityRatioSigmoidFactory : public reach::EvaluatorFactory
+{
+  using reach::EvaluatorFactory::EvaluatorFactory;
+
+  reach::Evaluator::ConstPtr create(const YAML::Node& config) const override;
+};
+
 /** @brief Computes the manipulability of a robot pose divided by the characteristic length of the robot */
 class ManipulabilityScaled : public ManipulabilityMoveIt
 {

--- a/src/evaluation/manipulability_moveit.cpp
+++ b/src/evaluation/manipulability_moveit.cpp
@@ -22,6 +22,7 @@
 #include <reach/plugin_utils.h>
 #include <reach/utils.h>
 #include <yaml-cpp/yaml.h>
+#include <cmath>
 
 static std::vector<Eigen::Index> getJacobianRowSubset(const YAML::Node& config, const std::string& key = "jacobian_row_"
                                                                                                          "subset")
@@ -177,6 +178,34 @@ reach::Evaluator::ConstPtr ManipulabilityRatioFactory::create(const YAML::Node& 
     throw std::runtime_error("Failed to initialize robot model pointer");
 
   return std::make_shared<ManipulabilityRatio>(model, planning_group, jacobian_row_subset);
+}
+
+double ManipulabilityRatioSigmoid::calculateScore(const Eigen::MatrixXd& jacobian_singular_values) const
+{
+  double manipulability = jacobian_singular_values.array().prod();
+  double manipulability_ratio = jacobian_singular_values.minCoeff() / jacobian_singular_values.maxCoeff();
+  double manipulability_scaled = std::sqrt(manipulability);
+  double manipulability_measure = std::sqrt(manipulability_ratio);
+
+  double score = manipulability_measure;
+
+  double shifted_score = 50.0 * (score - 0.15);
+  double sigmoid = 1.0 / (1.0 + std::exp(-shifted_score));
+
+  return sigmoid;
+}
+
+reach::Evaluator::ConstPtr ManipulabilityRatioSigmoidFactory::create(const YAML::Node& config) const
+{
+  auto planning_group = reach::get<std::string>(config, "planning_group");
+  std::vector<Eigen::Index> jacobian_row_subset = getJacobianRowSubset(config);
+
+  utils::initROS();
+  moveit::core::RobotModelConstPtr model = moveit::planning_interface::getSharedRobotModel("robot_description");
+  if (!model)
+    throw std::runtime_error("Failed to initialize robot model pointer");
+
+  return std::make_shared<ManipulabilityRatioSigmoid>(model, planning_group, jacobian_row_subset);
 }
 
 ManipulabilityScaled::ManipulabilityScaled(moveit::core::RobotModelConstPtr model, const std::string& planning_group,

--- a/src/plugins.cpp
+++ b/src/plugins.cpp
@@ -12,6 +12,7 @@ EXPORT_EVALUATOR_PLUGIN(reach_ros::evaluation::JointPenaltyMoveItFactory, JointP
 EXPORT_EVALUATOR_PLUGIN(reach_ros::evaluation::ManipulabilityMoveItFactory, ManipulabilityMoveIt)
 EXPORT_EVALUATOR_PLUGIN(reach_ros::evaluation::ManipulabilityScaledFactory, ManipulabilityScaledMoveIt)
 EXPORT_EVALUATOR_PLUGIN(reach_ros::evaluation::ManipulabilityRatioFactory, ManipulabilityRatioMoveIt)
+EXPORT_EVALUATOR_PLUGIN(reach_ros::evaluation::ManipulabilityRatioSigmoidFactory, ManipulabilityRatioSigmoidMoveIt)
 EXPORT_IK_SOLVER_PLUGIN(reach_ros::ik::MoveItIKSolverFactory, MoveItIKSolver)
 EXPORT_IK_SOLVER_PLUGIN(reach_ros::ik::DiscretizedMoveItIKSolverFactory, DiscretizedMoveItIKSolverFactory)
 EXPORT_TARGET_POSE_GENERATOR_PLUGIN(reach_ros::TransformedPointCloudTargetPoseGeneratorFactory,


### PR DESCRIPTION
Similar to ManipulabilityRatioMoveit but with an added sigmoid. The sigmoid makes it so that the score is almost always one except when the manipulability ratio is really bad, this makes the total score be the total number of reachable points, which is more understandable.